### PR TITLE
[Feature] Auth API 연동 및 토큰 관리 시스템 구현

### DIFF
--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -1,8 +1,10 @@
 "use client"
 
 import Link from "next/link"
-import { usePathname } from "next/navigation"
-import { Home, ListIcon, User } from "lucide-react"
+import { usePathname, useRouter } from "next/navigation"
+import { HomeIcon, ListBulletIcon, UserIcon, ArrowPathIcon } from "@heroicons/react/24/outline"
+import { useAuthContext } from "@/contexts/auth-context"
+import { useEffect } from "react"
 
 export default function MainLayout({
   children,
@@ -10,9 +12,31 @@ export default function MainLayout({
   children: React.ReactNode
 }) {
   const pathname = usePathname()
+  const router = useRouter()
+  const { isAuthenticated, isLoading } = useAuthContext()
 
   const isActive = (path: string) => {
     return pathname.startsWith(path)
+  }
+
+  // 인증 가드: 로그인하지 않은 사용자는 메인 페이지로 리다이렉트
+  useEffect(() => {
+    if (!isLoading && !isAuthenticated) {
+      router.replace("/")
+    }
+  }, [isLoading, isAuthenticated, router])
+
+  // 로딩 중이거나 인증되지 않은 경우 로딩 화면 표시
+  if (isLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-background">
+        <ArrowPathIcon className="w-12 h-12 animate-spin text-primary" />
+      </div>
+    )
+  }
+
+  if (!isAuthenticated) {
+    return null
   }
 
   return (
@@ -30,7 +54,7 @@ export default function MainLayout({
                 : "text-muted-foreground"
             }`}
           >
-            <ListIcon size={24} />
+            <ListBulletIcon className="w-6 h-6" />
             <span className="text-xs font-medium">질문</span>
           </Link>
 
@@ -42,7 +66,7 @@ export default function MainLayout({
                 : "text-muted-foreground"
             }`}
           >
-            <Home size={24} />
+            <HomeIcon className="w-6 h-6" />
             <span className="text-xs font-medium">홈</span>
           </Link>
 
@@ -54,7 +78,7 @@ export default function MainLayout({
                 : "text-muted-foreground"
             }`}
           >
-            <User size={24} />
+            <UserIcon className="w-6 h-6" />
             <span className="text-xs font-medium">마이페이지</span>
           </Link>
         </div>

--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -21,22 +21,24 @@ export default function MainLayout({
 
   // 인증 가드: 로그인하지 않은 사용자는 메인 페이지로 리다이렉트
   useEffect(() => {
-    if (!isLoading && !isAuthenticated) {
+    let isMounted = true
+
+    if (!isLoading && !isAuthenticated && isMounted) {
       router.replace("/")
+    }
+
+    return () => {
+      isMounted = false
     }
   }, [isLoading, isAuthenticated, router])
 
-  // 로딩 중이거나 인증되지 않은 경우 로딩 화면 표시
-  if (isLoading) {
+  // 로딩 중이거나, 아직 인증되지 않았다면 리다이렉트 되기 전까지 로딩 화면을 표시합니다.
+  if (isLoading || !isAuthenticated) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-background">
         <ArrowPathIcon className="w-12 h-12 animate-spin text-primary" />
       </div>
     )
-  }
-
-  if (!isAuthenticated) {
-    return null
   }
 
   return (

--- a/app/auth/callback/page.tsx
+++ b/app/auth/callback/page.tsx
@@ -1,0 +1,63 @@
+"use client"
+
+import { use, useEffect, useState } from "react"
+import { useRouter } from "next/navigation"
+import { useAuthContext } from "@/contexts/auth-context"
+import { ArrowPathIcon, XCircleIcon } from "@heroicons/react/24/outline"
+
+export default function AuthCallbackPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ access_token?: string }>
+}) {
+  const { access_token } = use(searchParams)
+  const router = useRouter()
+  const { login } = useAuthContext()
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const handleCallback = async () => {
+      if (!access_token) {
+        setError("로그인에 실패했습니다. 토큰이 없습니다.")
+        setTimeout(() => router.push("/"), 2000)
+        return
+      }
+
+      try {
+        await login(access_token)
+        // 온보딩 완료 상태로 설정
+        localStorage.setItem("onboarding_completed", "true")
+        router.push("/home")
+      } catch (err) {
+        console.error("로그인 처리 실패:", err)
+        setError("로그인 처리 중 오류가 발생했습니다.")
+        setTimeout(() => router.push("/"), 2000)
+      }
+    }
+
+    handleCallback()
+  }, [access_token, login, router])
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background">
+      <div className="text-center space-y-4">
+        {error ? (
+          <>
+            <div className="flex justify-center">
+              <XCircleIcon className="w-16 h-16 text-destructive" />
+            </div>
+            <p className="text-foreground/80">{error}</p>
+            <p className="text-sm text-muted-foreground">잠시 후 로그인 페이지로 이동합니다...</p>
+          </>
+        ) : (
+          <>
+            <div className="flex justify-center">
+              <ArrowPathIcon className="w-12 h-12 animate-spin text-primary" />
+            </div>
+            <p className="text-foreground/80">로그인 중...</p>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/app/auth/callback/page.tsx
+++ b/app/auth/callback/page.tsx
@@ -16,26 +16,45 @@ export default function AuthCallbackPage({
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
+    let isMounted = true
+    let timeoutId: NodeJS.Timeout | null = null
+
     const handleCallback = async () => {
       if (!access_token) {
-        setError("로그인에 실패했습니다. 토큰이 없습니다.")
-        setTimeout(() => router.push("/"), 2000)
+        if (isMounted) {
+          setError("로그인에 실패했습니다. 토큰이 없습니다.")
+        }
+        timeoutId = setTimeout(() => {
+          if (isMounted) router.push("/")
+        }, 2000)
         return
       }
 
       try {
         await login(access_token)
-        // 온보딩 완료 상태로 설정
-        localStorage.setItem("onboarding_completed", "true")
-        router.push("/home")
+        if (isMounted) {
+          router.push("/home")
+        }
       } catch (err) {
         console.error("로그인 처리 실패:", err)
-        setError("로그인 처리 중 오류가 발생했습니다.")
-        setTimeout(() => router.push("/"), 2000)
+        if (isMounted) {
+          setError("로그인 처리 중 오류가 발생했습니다.")
+        }
+        timeoutId = setTimeout(() => {
+          if (isMounted) router.push("/")
+        }, 2000)
       }
     }
 
     handleCallback()
+
+    // cleanup: 컴포넌트 언마운트 시 타이머 정리 및 상태 업데이트 방지
+    return () => {
+      isMounted = false
+      if (timeoutId) {
+        clearTimeout(timeoutId)
+      }
+    }
   }, [access_token, login, router])
 
   return (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,38 +4,35 @@ import { useState, useEffect } from "react"
 import { useRouter } from "next/navigation"
 import { LoadingScreen } from "@/components/loading-screen"
 import { LoginPage } from "@/components/login-page"
+import { useAuthContext } from "@/contexts/auth-context"
 
 export default function RootPage() {
   const router = useRouter()
   const [isLoading, setIsLoading] = useState(true)
+  const { isAuthenticated, isLoading: authLoading } = useAuthContext()
 
   useEffect(() => {
-    // Check if user has completed onboarding
-    const checkAuth = () => {
-      if (typeof window !== "undefined") {
-        const hasCompletedOnboarding = localStorage.getItem("onboarding_completed") === "true"
-        if (hasCompletedOnboarding) {
-          // Redirect to home page
-          router.replace("/home")
-          return
-        }
-      }
-      setIsLoading(false)
+    // 인증 로딩이 완료될 때까지 대기
+    if (authLoading) {
+      return
     }
 
-    const timer = setTimeout(checkAuth, 100)
-    return () => clearTimeout(timer)
-  }, [router])
+    // 로그인되어 있으면 바로 홈으로 이동
+    if (isAuthenticated) {
+      router.replace("/home")
+      return
+    }
+
+    // 로그인되어 있지 않으면 온보딩 표시
+    setIsLoading(false)
+  }, [authLoading, isAuthenticated, router])
 
   const handleLoginSuccess = () => {
-    if (typeof window !== "undefined") {
-      localStorage.setItem("onboarding_completed", "true")
-    }
-    // Redirect to home page after onboarding
-    router.push("/home")
+    // 로그인 성공 시 처리는 AuthContext에서 담당
+    // 여기서는 아무것도 하지 않아도 됨
   }
 
-  if (isLoading) {
+  if (isLoading || authLoading) {
     return <LoadingScreen />
   }
 

--- a/components/client-providers.tsx
+++ b/components/client-providers.tsx
@@ -1,7 +1,12 @@
 "use client"
 
 import { QuestionsProvider } from "@/contexts/questions-context"
+import { AuthProvider } from "@/contexts/auth-context"
 
 export function ClientProviders({ children }: { children: React.ReactNode }) {
-  return <QuestionsProvider>{children}</QuestionsProvider>
+  return (
+    <AuthProvider>
+      <QuestionsProvider>{children}</QuestionsProvider>
+    </AuthProvider>
+  )
 }

--- a/contexts/auth-context.tsx
+++ b/contexts/auth-context.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import { createContext, useContext } from "react"
+import { useAuth } from "@/hooks/use-auth"
+import type { User } from "@/lib/auth-api"
+
+interface AuthContextType {
+  user: User | null
+  isLoading: boolean
+  isAuthenticated: boolean
+  accessToken: string | null
+  login: (token: string) => Promise<void>
+  logout: () => Promise<void>
+  deleteAccount: () => Promise<void>
+  refreshToken: () => Promise<string>
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined)
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const authState = useAuth()
+
+  return <AuthContext.Provider value={authState}>{children}</AuthContext.Provider>
+}
+
+export function useAuthContext() {
+  const context = useContext(AuthContext)
+  if (!context) {
+    throw new Error("useAuthContext must be used within AuthProvider")
+  }
+  return context
+}

--- a/hooks/use-auth.ts
+++ b/hooks/use-auth.ts
@@ -1,0 +1,143 @@
+"use client"
+
+import { useState, useEffect, useCallback } from "react"
+import {
+  getMe,
+  logout as apiLogout,
+  deleteAccount as apiDeleteAccount,
+  refreshAccessToken,
+  getStoredAccessToken,
+  setStoredAccessToken,
+  removeStoredAccessToken,
+  type User,
+} from "@/lib/auth-api"
+
+export function useAuth() {
+  const [user, setUser] = useState<User | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [accessToken, setAccessToken] = useState<string | null>(null)
+
+  /**
+   * 로그인 처리 (OAuth 콜백에서 호출)
+   */
+  const login = useCallback(async (token: string) => {
+    try {
+      setStoredAccessToken(token)
+      setAccessToken(token)
+
+      const userData = await getMe(token)
+      setUser(userData)
+    } catch (error) {
+      console.error("로그인 실패:", error)
+      removeStoredAccessToken()
+      setAccessToken(null)
+      setUser(null)
+      throw error
+    }
+  }, [])
+
+  /**
+   * 로그아웃 처리
+   */
+  const logout = useCallback(async () => {
+    try {
+      await apiLogout()
+    } catch (error) {
+      console.error("로그아웃 API 실패:", error)
+    } finally {
+      // API 실패 여부와 관계없이 로컬 상태 초기화
+      removeStoredAccessToken()
+      setAccessToken(null)
+      setUser(null)
+    }
+  }, [])
+
+  /**
+   * 회원 탈퇴 처리
+   */
+  const deleteAccount = useCallback(async () => {
+    if (!accessToken) {
+      throw new Error("로그인이 필요합니다")
+    }
+
+    try {
+      await apiDeleteAccount(accessToken)
+      removeStoredAccessToken()
+      setAccessToken(null)
+      setUser(null)
+    } catch (error) {
+      console.error("회원 탈퇴 실패:", error)
+      throw error
+    }
+  }, [accessToken])
+
+  /**
+   * 토큰 갱신 처리
+   */
+  const refreshToken = useCallback(async () => {
+    try {
+      const newToken = await refreshAccessToken()
+      setStoredAccessToken(newToken)
+      setAccessToken(newToken)
+      return newToken
+    } catch (error) {
+      console.error("토큰 갱신 실패:", error)
+      // 갱신 실패 시 로그아웃 처리
+      removeStoredAccessToken()
+      setAccessToken(null)
+      setUser(null)
+      throw error
+    }
+  }, [])
+
+  /**
+   * 초기 인증 상태 확인
+   */
+  useEffect(() => {
+    const initAuth = async () => {
+      const storedToken = getStoredAccessToken()
+
+      if (!storedToken) {
+        setIsLoading(false)
+        return
+      }
+
+      try {
+        setAccessToken(storedToken)
+        const userData = await getMe(storedToken)
+        setUser(userData)
+      } catch (error) {
+        console.error("인증 상태 확인 실패:", error)
+
+        // 401 에러면 토큰 갱신 시도
+        try {
+          const newToken = await refreshAccessToken()
+          setStoredAccessToken(newToken)
+          setAccessToken(newToken)
+          const userData = await getMe(newToken)
+          setUser(userData)
+        } catch (refreshError) {
+          console.error("토큰 갱신 실패:", refreshError)
+          removeStoredAccessToken()
+          setAccessToken(null)
+          setUser(null)
+        }
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    initAuth()
+  }, [])
+
+  return {
+    user,
+    isLoading,
+    isAuthenticated: !!user,
+    accessToken,
+    login,
+    logout,
+    deleteAccount,
+    refreshToken,
+  }
+}

--- a/hooks/use-auth.ts
+++ b/hooks/use-auth.ts
@@ -94,40 +94,60 @@ export function useAuth() {
    * 초기 인증 상태 확인
    */
   useEffect(() => {
+    let isMounted = true
+
     const initAuth = async () => {
       const storedToken = getStoredAccessToken()
 
       if (!storedToken) {
-        setIsLoading(false)
+        if (isMounted) setIsLoading(false)
         return
       }
 
       try {
-        setAccessToken(storedToken)
+        if (isMounted) setAccessToken(storedToken)
         const userData = await getMe(storedToken)
-        setUser(userData)
-      } catch (error) {
+        if (isMounted) setUser(userData)
+      } catch (error: any) {
         console.error("인증 상태 확인 실패:", error)
 
-        // 401 에러면 토큰 갱신 시도
-        try {
-          const newToken = await refreshAccessToken()
-          setStoredAccessToken(newToken)
-          setAccessToken(newToken)
-          const userData = await getMe(newToken)
-          setUser(userData)
-        } catch (refreshError) {
-          console.error("토큰 갱신 실패:", refreshError)
+        // 401 에러인 경우에만 토큰 갱신 시도
+        if (error?.status === 401) {
+          try {
+            const newToken = await refreshAccessToken()
+            if (isMounted) {
+              setStoredAccessToken(newToken)
+              setAccessToken(newToken)
+            }
+            const userData = await getMe(newToken)
+            if (isMounted) setUser(userData)
+          } catch (refreshError) {
+            console.error("토큰 갱신 실패:", refreshError)
+            removeStoredAccessToken()
+            if (isMounted) {
+              setAccessToken(null)
+              setUser(null)
+            }
+          }
+        } else {
+          // 401이 아닌 다른 에러는 토큰 갱신 시도 없이 바로 로그아웃 처리
           removeStoredAccessToken()
-          setAccessToken(null)
-          setUser(null)
+          if (isMounted) {
+            setAccessToken(null)
+            setUser(null)
+          }
         }
       } finally {
-        setIsLoading(false)
+        if (isMounted) setIsLoading(false)
       }
     }
 
     initAuth()
+
+    // cleanup: 컴포넌트 언마운트 시 상태 업데이트 방지
+    return () => {
+      isMounted = false
+    }
   }, [])
 
   return {

--- a/lib/auth-api.ts
+++ b/lib/auth-api.ts
@@ -51,7 +51,10 @@ export async function getMe(accessToken: string): Promise<User> {
   })
 
   if (!response.ok) {
-    throw new Error(`Failed to fetch user info: ${response.status}`)
+    // 401 에러인 경우 별도 처리를 위해 status를 포함한 에러 throw
+    const error = new Error(`Failed to fetch user info: ${response.status}`)
+    ;(error as any).status = response.status
+    throw error
   }
 
   const result: ApiResponse<User> = await response.json()

--- a/lib/auth-api.ts
+++ b/lib/auth-api.ts
@@ -1,0 +1,131 @@
+/**
+ * Auth API Service
+ * 인증 관련 API 호출을 담당하는 서비스 레이어
+ */
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"
+
+// API 응답 공통 타입
+interface ApiResponse<T> {
+  timestamp: string
+  status: number
+  code: string
+  message: string
+  data: T
+}
+
+// 사용자 정보 타입
+export interface User {
+  id: number
+  nickname: string
+  email?: string // 백엔드에서 추가 예정
+  providerId: string
+  role: "USER" | "ADMIN"
+  isDeleted: boolean
+}
+
+// 토큰 갱신 응답 타입
+interface RefreshTokenResponse {
+  accessToken: string
+  expiresIn: number
+}
+
+/**
+ * Google OAuth 로그인 URL 생성
+ */
+export function getGoogleLoginUrl(): string {
+  return `${API_URL}/oauth2/authorization/google`
+}
+
+/**
+ * 내 정보 조회
+ */
+export async function getMe(accessToken: string): Promise<User> {
+  const response = await fetch(`${API_URL}/api/v1/users/me`, {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+    },
+    credentials: "include", // 쿠키 포함
+  })
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch user info: ${response.status}`)
+  }
+
+  const result: ApiResponse<User> = await response.json()
+  return result.data
+}
+
+/**
+ * 토큰 갱신
+ */
+export async function refreshAccessToken(): Promise<string> {
+  const response = await fetch(`${API_URL}/api/v1/auth/refresh`, {
+    method: "POST",
+    credentials: "include", // refreshToken 쿠키 자동 포함
+  })
+
+  if (!response.ok) {
+    throw new Error(`Token refresh failed: ${response.status}`)
+  }
+
+  const result: ApiResponse<RefreshTokenResponse> = await response.json()
+  return result.data.accessToken
+}
+
+/**
+ * 로그아웃
+ */
+export async function logout(): Promise<void> {
+  const response = await fetch(`${API_URL}/api/v1/auth/logout`, {
+    method: "POST",
+    credentials: "include", // refreshToken 쿠키 포함
+  })
+
+  if (!response.ok) {
+    throw new Error(`Logout failed: ${response.status}`)
+  }
+}
+
+/**
+ * 회원 탈퇴
+ */
+export async function deleteAccount(accessToken: string): Promise<void> {
+  const response = await fetch(`${API_URL}/api/v1/users/me`, {
+    method: "DELETE",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+    credentials: "include",
+  })
+
+  if (!response.ok) {
+    throw new Error(`Account deletion failed: ${response.status}`)
+  }
+}
+
+/**
+ * localStorage에서 accessToken 가져오기
+ */
+export function getStoredAccessToken(): string | null {
+  if (typeof window === "undefined") return null
+  return localStorage.getItem("access_token")
+}
+
+/**
+ * localStorage에 accessToken 저장
+ */
+export function setStoredAccessToken(token: string): void {
+  if (typeof window === "undefined") return
+  localStorage.setItem("access_token", token)
+}
+
+/**
+ * localStorage에서 accessToken 삭제
+ */
+export function removeStoredAccessToken(): void {
+  if (typeof window === "undefined") return
+  localStorage.removeItem("access_token")
+}


### PR DESCRIPTION
## 🔗 Issue Link
<!-- 관련 이슈 번호를 적어주세요. 해당 PR merge와 함께 이슈를 닫으려면 `close #이슈번호`를 적어주세요. -->
- #5 

## 🎯 What I Did
<!-- 이번 PR에서 구현하거나 수정한 주요 내용을 간결히 기술하세요. -->
- Google OAuth 인증 시스템 프론트엔드 연동
- JWT 토큰 관리 및 자동 갱신 로직 구현
- 비로그인 사용자 접근 제한 라우팅 가드 적용
- OAuth 콜백 페이지 구현

## 🔍 Review Points
<!-- 리뷰어가 집중해서 봐야 할 부분이나 검증이 필요한 로직을 적어주세요. -->
- `lib/auth-api.ts`: API 엔드포인트 URL 및 에러 핸들링
- `hooks/use-auth.ts`: 토큰 만료 시 자동 갱신 로직
- `app/(main)/layout.tsx`: 인증 가드가 모든 메인 페이지에 적용되는지 확인
- `app/auth/callback/page.tsx`: OAuth 콜백 후 홈 리다이렉트 처리

## 🚀 Notes
<!-- 실행, 환경 설정, 테스트에 필요한 추가 정보가 있다면 적어주세요. -->
- 백엔드 API URL은 환경변수 `NEXT_PUBLIC_API_URL`로 설정 필요 (기본값: http://localhost:8080)
- Access Token은 localStorage에 저장됨
- Refresh Token은 httpOnly 쿠키로 백엔드에서 관리

