### PR TITLE
[Feature] 홈/질문/마이페이지 UI 전면 개선 및 API 연동

### DIFF
--- a/app/(main)/home/page.tsx
+++ b/app/(main)/home/page.tsx
@@ -1,13 +1,17 @@
 "use client"
 
-import { useEffect } from "react"
+import { useEffect, useCallback, useState } from "react"
 import { useRouter } from "next/navigation"
 import { QuestionCard } from "@/components/question-card"
 import { LoadingSkeleton } from "@/components/loading-skeleton"
+import { PullToRefresh } from "@/components/pull-to-refresh"
 import { useQuestionsContext } from "@/contexts/questions-context"
 import { useAuthContext } from "@/contexts/auth-context"
-import { ERROR_MESSAGES } from "@/hooks/use-questions"
-import { ExclamationTriangleIcon } from "@heroicons/react/24/solid"
+import { ERROR_MESSAGES, toQuestion } from "@/hooks/use-questions"
+import { BellIcon, ChartBarIcon } from "@heroicons/react/24/outline"
+import Link from "next/link"
+import * as questionsApi from "@/lib/api/questions"
+import type { Question } from "@/types/entities"
 
 export default function HomePage() {
   const router = useRouter()
@@ -21,13 +25,35 @@ export default function HomePage() {
     loadingId,
     isLoading,
     error,
+    refreshQuestion,
+    refreshingId,
   } = useQuestionsContext()
 
-  // 인증 완료 후 오늘의 질문 로드
+  const [topQuestions, setTopQuestions] = useState<Question[]>([])
+  const [isLoadingTop, setIsLoadingTop] = useState(true)
+
+  // 인증 완료 후 오늘의 질문 & Top 5 로드
   useEffect(() => {
     if (authLoading) return
     fetchTodayQuestion()
+
+    const fetchTopQuestions = async () => {
+      try {
+        setIsLoadingTop(true)
+        const response = await questionsApi.getTopQuestions()
+        setTopQuestions(response.data.map((q) => toQuestion(q)))
+      } catch {
+        // 에러 시 빈 배열 유지
+      } finally {
+        setIsLoadingTop(false)
+      }
+    }
+    fetchTopQuestions()
   }, [fetchTodayQuestion, authLoading])
+
+  const handlePullRefresh = useCallback(async () => {
+    await fetchTodayQuestion()
+  }, [fetchTodayQuestion])
 
   const question = todayQuestion
 
@@ -35,33 +61,48 @@ export default function HomePage() {
     return <LoadingSkeleton />
   }
 
+  // 오늘의 질문이 없는 경우 (에러 vs 아직 없음 구분)
   if (!question) {
+    const isNoQuestionToday = error === ERROR_MESSAGES.NO_QUESTION_TODAY
+    const isError = error && !isNoQuestionToday
+
     return (
-      <div className="w-full max-w-2xl mx-auto px-6 pt-8 pb-12 md:px-8 md:pt-10 md:pb-20">
-        <div className="text-center py-16 space-y-4">
-          <div className="flex justify-center">
-            <div className="w-16 h-16 bg-destructive/10 rounded-full flex items-center justify-center">
-              <ExclamationTriangleIcon className="w-8 h-8 text-destructive/60" />
-            </div>
-          </div>
-          <div className="space-y-3">
-            <div className="space-y-1">
-              <p className="text-base font-medium text-foreground">
-                {error || "오늘의 질문을 불러올 수 없습니다"}
+      <div className="w-full max-w-2xl mx-auto px-5 pt-6 pb-12 md:px-8 md:pt-10 md:pb-20">
+        <h1 className="text-2xl font-bold text-foreground mb-6">오늘의 질문</h1>
+
+        <div className="flex flex-col items-center pt-65">
+          {isError ? (
+            <>
+              <p className="text-4xl font-bold text-muted-foreground/40 mb-3">
+                앗!
               </p>
-              {error !== ERROR_MESSAGES.NO_QUESTION_TODAY && (
-                <p className="text-sm text-muted-foreground">잠시 후 다시 시도해주세요</p>
-              )}
-            </div>
-            {error !== ERROR_MESSAGES.NO_QUESTION_TODAY && (
+              <p className="text-[15px] text-muted-foreground mb-6">
+                질문을 불러오지 못했어요
+              </p>
               <button
                 onClick={() => window.location.reload()}
-                className="px-4 py-2 bg-primary text-primary-foreground rounded-lg font-medium active:scale-95 transition-transform"
+                className="h-12 w-48 bg-primary/60 text-white rounded-xl font-semibold text-[15px] flex items-center justify-center active:scale-95 transition-transform"
               >
-                새로고침
+                다시 시도
               </button>
-            )}
-          </div>
+            </>
+          ) : (
+            <>
+              <BellIcon className="w-16 h-16 text-primary/60 mb-4" />
+              <p className="text-[15px] text-muted-foreground mb-1">
+                아직 오늘의 질문이 없어요
+              </p>
+              <p className="text-[13px] text-muted-foreground/70 mb-6">
+                알림을 켜두면 새 질문을 바로 받아볼 수 있어요
+              </p>
+              <Link
+                href="/settings"
+                className="h-12 w-48 bg-primary/60 text-white rounded-xl font-semibold text-[15px] flex items-center justify-center active:scale-95 transition-transform"
+              >
+                알림 설정하기
+              </Link>
+            </>
+          )}
         </div>
       </div>
     )
@@ -79,42 +120,59 @@ export default function HomePage() {
   }
 
   return (
-    <div className="w-full max-w-2xl mx-auto px-5 pt-6 pb-12 md:px-8 md:pt-10 md:pb-20">
-      <h1 className="text-2xl font-bold text-foreground mb-6">오늘의 질문</h1>
-
-      {/* 오늘의 질문 */}
-      <div className="space-y-8">
-        <div
-          onClick={handleQuestionClick}
-          className="rounded-lg bg-card border border-2 border-primary shadow-sm cursor-pointer"
-        >
-          <QuestionCard
-            question={question}
-            onVote={handleVote}
-            selectedOption={userVote ?? undefined}
-            showResults={hasVoted}
-            isLoading={loadingId === question.id}
-            showDate={true}
-            hasVoted={hasVoted}
-          />
-        </div>
-
-        {/* 월간 반응 뜨거운 질문 */}
-        <div className="bg-card rounded-lg border border-border p-4 md:p-6">
-          <h2 className="text-lg font-semibold text-foreground mb-4">🔥 월간 반응 뜨거운 질문</h2>
-          <p className="text-sm text-muted-foreground text-center py-4">
-            준비 중입니다
+    <PullToRefresh onRefresh={handlePullRefresh}>
+      <div className="w-full max-w-2xl mx-auto px-5 pt-6 pb-12 md:px-8 md:pt-10 md:pb-20">
+      {/* 오늘의 질문 - 메인 영역 */}
+      <div className="min-h-[60vh] flex flex-col justify-center py-8">
+        <div className="text-center mb-6">
+          <h1 className="text-2xl font-bold text-foreground mb-2">오늘의 질문</h1>
+          <p className="text-[13px] text-foreground/80 leading-relaxed">
+            지금 이 순간에도 누군가 선택하고 있어요
+            <br />
+            나와 같은 생각을 가진 사람, 몇 %일까요?
           </p>
         </div>
-
-        {/* 베스트 공감 댓글 */}
-        <div className="bg-card rounded-lg border border-border p-4 md:p-6">
-          <h2 className="text-lg font-semibold text-foreground mb-4">💬 베스트 공감 댓글</h2>
-          <p className="text-sm text-muted-foreground text-center py-4">
-            준비 중입니다
-          </p>
-        </div>
+        <QuestionCard
+          question={question}
+          onVote={handleVote}
+          onRefresh={() => refreshQuestion(question.id)}
+          onDetailClick={handleQuestionClick}
+          selectedOption={userVote ?? undefined}
+          showResults={hasVoted}
+          isLoading={loadingId === question.id}
+          isRefreshing={refreshingId === question.id}
+          showDate={true}
+          hasVoted={hasVoted}
+          showDescription={true}
+        />
       </div>
+
+      {/* Top 5 - 스크롤해서 볼 수 있는 영역 */}
+      {!isLoadingTop && topQuestions.length > 0 && (
+        <div className="mt-8 space-y-4">
+          <h2 className="text-lg font-semibold text-foreground flex items-center gap-2">
+            <ChartBarIcon className="w-5 h-5 text-primary" />
+            Top 5
+          </h2>
+          <div className="space-y-4">
+            {topQuestions.map((q) => (
+              <QuestionCard
+                key={q.id}
+                question={q}
+                onVote={(optionIndex) => castVote(q.id, optionIndex)}
+                onDetailClick={() => router.push(`/questions/${q.id}`)}
+                showResults={hasUserVoted(q.id)}
+                selectedOption={getUserVote(q.id) ?? undefined}
+                isLoading={loadingId === q.id}
+                showDate={true}
+                hasVoted={hasUserVoted(q.id)}
+                showDescription={true}
+              />
+            ))}
+          </div>
+        </div>
+      )}
     </div>
+    </PullToRefresh>
   )
 }

--- a/app/(main)/home/page.tsx
+++ b/app/(main)/home/page.tsx
@@ -80,7 +80,7 @@ export default function HomePage() {
                 질문을 불러오지 못했어요
               </p>
               <button
-                onClick={() => window.location.reload()}
+                onClick={() => fetchTodayQuestion()}
                 className="h-12 w-48 bg-primary/60 text-white rounded-xl font-semibold text-[15px] flex items-center justify-center active:scale-95 transition-transform"
               >
                 다시 시도

--- a/app/(main)/home/page.tsx
+++ b/app/(main)/home/page.tsx
@@ -70,7 +70,7 @@ export default function HomePage() {
       <div className="w-full max-w-2xl mx-auto px-5 pt-6 pb-12 md:px-8 md:pt-10 md:pb-20">
         <h1 className="text-2xl font-bold text-foreground mb-6">오늘의 질문</h1>
 
-        <div className="flex flex-col items-center pt-65">
+        <div className="flex flex-col items-center pt-16">
           {isError ? (
             <>
               <p className="text-4xl font-bold text-muted-foreground/40 mb-3">

--- a/app/(main)/profile/page.tsx
+++ b/app/(main)/profile/page.tsx
@@ -1,9 +1,9 @@
 "use client"
 
-import { Cog6ToothIcon } from "@heroicons/react/24/outline"
+import { Cog6ToothIcon, TicketIcon } from "@heroicons/react/24/outline"
+import { FireIcon } from "@heroicons/react/24/solid"
 import { UserGroupIcon, ScaleIcon, RocketLaunchIcon } from "@heroicons/react/24/solid"
 import { useUserProfile } from "@/hooks/use-user-profile"
-import { ActivityChart } from "@/components/activity-chart"
 import { LoadingSkeleton } from "@/components/loading-skeleton"
 import { useRouter } from "next/navigation"
 
@@ -82,7 +82,8 @@ export default function ProfilePage() {
           <TendencyIcon className="w-14 h-14 text-primary/70" />
         </div>
         <h2 className="text-2xl font-bold text-foreground mb-2">{profile.username}</h2>
-        <span className="inline-block px-3 py-1 bg-primary/10 text-primary rounded-full text-sm font-medium">
+        <span className="inline-flex items-center gap-1.5 px-3 py-1 bg-orange-100 text-orange-600 rounded-full text-sm font-medium">
+          <FireIcon className="w-4 h-4" />
           {profile.currentStreak}일 연속 참여 중
         </span>
       </div>
@@ -115,11 +116,39 @@ export default function ProfilePage() {
           </div>
         </div>
 
-        {/* 최근 활동 */}
+        {/* 7일 연속 참여 보상 */}
         <div className="bg-card rounded-xl border border-border p-5">
-          <h3 className="font-semibold text-foreground mb-4">최근 7일</h3>
-          <ActivityChart data={profile.recentActivity} />
+          <div className="flex items-center justify-between mb-4">
+            <h3 className="font-semibold text-foreground">7일 연속 참여 보상</h3>
+            <div className="flex items-center gap-1.5 px-2.5 py-1 bg-primary/10 rounded-full">
+              <TicketIcon className="w-4 h-4 text-primary" />
+              <span className="text-sm font-semibold text-primary">1개</span>
+            </div>
+          </div>
+
+          {/* 프로그레스 */}
+          <div className="mb-3">
+            <div className="flex items-center justify-between mb-2">
+              <span className="text-sm text-muted-foreground">
+                {profile.currentStreak >= 7 ? "달성 완료!" : `${profile.currentStreak}/7일`}
+              </span>
+              {profile.currentStreak >= 7 && (
+                <span className="text-xs text-primary font-medium">+1 획득 가능</span>
+              )}
+            </div>
+            <div className="h-2 bg-muted rounded-full overflow-hidden">
+              <div
+                className="h-full bg-primary/60 rounded-full transition-all duration-300"
+                style={{ width: `${Math.min((profile.currentStreak / 7) * 100, 100)}%` }}
+              />
+            </div>
+          </div>
+
+          <p className="text-sm text-muted-foreground">
+            7일 연속 참여하면 놓친 투표 결과를 열어볼 수 있어요
+          </p>
         </div>
+
       </div>
     </div>
   )

--- a/app/(main)/profile/page.tsx
+++ b/app/(main)/profile/page.tsx
@@ -16,11 +16,17 @@ interface TendencyInfo {
   icon: typeof UserGroupIcon
 }
 
+// 성향 분류 기준값
+const TENDENCY_THRESHOLD = {
+  MAJORITY: 71,  // 71% 이상: 대세파
+  BALANCED: 31,  // 31% 이상: 균형파, 미만: 소신파
+}
+
 // majorityRate에 따른 성향 결정
 function getTendency(majorityRate: number): TendencyInfo {
-  if (majorityRate >= 71) {
+  if (majorityRate >= TENDENCY_THRESHOLD.MAJORITY) {
     return { type: "majority", name: "대중과 통하는 공감자", icon: UserGroupIcon }
-  } else if (majorityRate >= 31) {
+  } else if (majorityRate >= TENDENCY_THRESHOLD.BALANCED) {
     return { type: "balanced", name: "균형 잡힌 중재자", icon: ScaleIcon }
   } else {
     return { type: "independent", name: "흔들리지 않는 개척자", icon: RocketLaunchIcon }

--- a/app/(main)/profile/page.tsx
+++ b/app/(main)/profile/page.tsx
@@ -1,14 +1,42 @@
 "use client"
 
 import { Cog6ToothIcon } from "@heroicons/react/24/outline"
-import { UserCircleIcon } from "@heroicons/react/24/solid"
+import { UserGroupIcon, ScaleIcon, RocketLaunchIcon } from "@heroicons/react/24/solid"
 import { useUserProfile } from "@/hooks/use-user-profile"
 import { ActivityChart } from "@/components/activity-chart"
+import { LoadingSkeleton } from "@/components/loading-skeleton"
 import { useRouter } from "next/navigation"
 
+// 투표 성향 타입 정의
+type TendencyType = "majority" | "balanced" | "independent"
+
+interface TendencyInfo {
+  type: TendencyType
+  name: string
+  icon: typeof UserGroupIcon
+}
+
+// majorityRate에 따른 성향 결정
+function getTendency(majorityRate: number): TendencyInfo {
+  if (majorityRate >= 71) {
+    return { type: "majority", name: "대중과 통하는 공감자", icon: UserGroupIcon }
+  } else if (majorityRate >= 31) {
+    return { type: "balanced", name: "균형 잡힌 중재자", icon: ScaleIcon }
+  } else {
+    return { type: "independent", name: "흔들리지 않는 개척자", icon: RocketLaunchIcon }
+  }
+}
+
 export default function ProfilePage() {
-  const { profile, getDaysSinceJoin } = useUserProfile()
+  const { profile, isLoading } = useUserProfile()
   const router = useRouter()
+
+  if (isLoading) {
+    return <LoadingSkeleton />
+  }
+
+  const tendency = getTendency(profile.majorityRate)
+  const TendencyIcon = tendency.icon
 
   const stats = [
     {
@@ -30,57 +58,62 @@ export default function ProfilePage() {
 
   return (
     <div className="w-full max-w-2xl mx-auto px-5 pt-6 pb-12 md:px-8 md:pt-10 md:pb-20">
-      {/* Header with settings */}
-      <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-bold text-foreground">프로필</h1>
+      {/* 설정 버튼 */}
+      <div className="flex justify-end mb-2">
         <button
           onClick={() => router.push('/settings')}
-          className="p-2.5 active:bg-muted rounded-lg transition-colors"
+          className="p-2 active:bg-muted rounded-lg transition-colors"
           aria-label="설정"
         >
-          <Cog6ToothIcon className="w-6 h-6 text-foreground" />
+          <Cog6ToothIcon className="w-5 h-5 text-muted-foreground" />
         </button>
       </div>
 
-      <div className="space-y-8">
-      {/* Profile Header */}
-      <div className="bg-card rounded-lg border border-border p-6">
-        <div className="flex items-center gap-4">
-          <div className="w-20 h-20 flex-shrink-0">
-            <UserCircleIcon className="w-full h-full text-primary/60" />
-          </div>
-          <div className="flex-1 space-y-2">
-            <h2 className="text-xl md:text-2xl font-semibold text-foreground">{profile.username}</h2>
-            <div className="flex items-center gap-2 text-sm text-muted-foreground">
-              <span className="px-2.5 py-1 bg-primary/10 text-primary rounded-md font-medium">
-                {getDaysSinceJoin()}일째 참여 중
-              </span>
-            </div>
-          </div>
+      {/* 프로필 영역 */}
+      <div className="text-center mb-8">
+        {/* 성향 아바타 */}
+        <div className="w-28 h-28 mx-auto mb-4 rounded-full bg-primary/5 flex items-center justify-center border-2 border-primary/20">
+          <TendencyIcon className="w-14 h-14 text-primary/70" />
         </div>
+        <h2 className="text-2xl font-bold text-foreground mb-2">{profile.username}</h2>
+        <span className="inline-block px-3 py-1 bg-primary/10 text-primary rounded-full text-sm font-medium">
+          {profile.currentStreak}일 연속 참여 중
+        </span>
       </div>
 
-      {/* Stats Grid */}
-      <div className="grid grid-cols-3 gap-3 md:gap-4">
+      {/* Stats */}
+      <div className="grid grid-cols-3 gap-2 mb-8">
         {stats.map((stat, index) => (
-          <div key={index} className="bg-card rounded-lg border border-border p-4 md:p-5 space-y-2">
-            <p className="text-xs md:text-sm text-muted-foreground leading-tight">{stat.label}</p>
-            <div className="flex items-baseline gap-1">
-              <p className="text-2xl md:text-3xl font-bold text-foreground">{stat.value}</p>
-              <span className="text-xs md:text-sm text-muted-foreground">{stat.description}</span>
-            </div>
+          <div key={index} className="text-center py-4">
+            <p className="text-2xl md:text-3xl font-bold text-foreground">
+              {stat.value}<span className="text-base font-normal text-muted-foreground">{stat.description}</span>
+            </p>
+            <p className="text-sm text-muted-foreground mt-1">{stat.label}</p>
           </div>
         ))}
       </div>
 
-      {/* Recent Activity */}
-      <div className="bg-card rounded-lg border border-border p-6 space-y-5">
-        <div className="space-y-1.5">
-          <h3 className="text-lg md:text-xl font-semibold text-foreground">최근 활동</h3>
-          <p className="text-sm text-muted-foreground">지난 7일간의 참여 현황</p>
+      <div className="space-y-4">
+        {/* 나의 투표 성향 */}
+        <div className="bg-card rounded-xl border border-border p-5">
+          <div className="flex items-center justify-between mb-3">
+            <h3 className="font-semibold text-foreground">나의 투표 성향</h3>
+            <span className="px-3 py-1 bg-primary/10 text-primary rounded-full text-sm font-medium">{tendency.name}</span>
+          </div>
+          <div className="flex items-end gap-3 mb-4">
+            <p className="text-4xl font-bold text-foreground">{profile.majorityRate}<span className="text-lg font-medium">%</span></p>
+            <p className="text-sm text-muted-foreground pb-1">다수의 선택과 일치</p>
+          </div>
+          <div className="h-1.5 bg-muted rounded-full overflow-hidden">
+            <div className="h-full bg-primary/60 rounded-full" style={{ width: `${profile.majorityRate}%` }} />
+          </div>
         </div>
-        <ActivityChart data={profile.recentActivity} maxValue={10} />
-      </div>
+
+        {/* 최근 활동 */}
+        <div className="bg-card rounded-xl border border-border p-5">
+          <h3 className="font-semibold text-foreground mb-4">최근 7일</h3>
+          <ActivityChart data={profile.recentActivity} />
+        </div>
       </div>
     </div>
   )

--- a/app/(main)/questions/[id]/page.tsx
+++ b/app/(main)/questions/[id]/page.tsx
@@ -70,14 +70,13 @@ export default function QuestionDetailPage({ params }: { params: Promise<{ id: s
     return (
       <div className="w-full max-w-2xl mx-auto px-5 pt-6 pb-12 md:px-8 md:pt-10 md:pb-20">
         {/* Back button */}
-        <div className="flex items-center gap-3 mb-6">
+        <div className="mb-4">
           <button
             onClick={() => router.back()}
             className="p-2.5 active:bg-muted rounded-lg transition-colors"
           >
             <ArrowLeftIcon className="w-6 h-6 text-foreground" />
           </button>
-          <h1 className="text-2xl font-bold text-foreground">질문 상세</h1>
         </div>
 
         <div className="space-y-8">
@@ -86,16 +85,18 @@ export default function QuestionDetailPage({ params }: { params: Promise<{ id: s
             onVote={() => {}}
             showResults={false}
             isLoading={false}
-            isToday={question.isToday}
             showDate={true}
             hasVoted={false}
             hideVoteAfterMessage={true}
             showDescription={true}
           />
 
-          <div className="text-center py-8 bg-card rounded-lg border border-border">
-            <p className="text-base text-muted-foreground leading-relaxed">
-              종료된 질문입니다. 투표에 참여하지 않아 결과와 댓글을 볼 수 없습니다.
+          <div className="text-center py-8 bg-card rounded-lg border border-border space-y-2">
+            <p className="text-base font-medium text-foreground">
+              종료된 질문입니다.
+            </p>
+            <p className="text-sm text-muted-foreground">
+              투표에 참여하지 않아 결과와 댓글을 볼 수 없습니다.
             </p>
           </div>
         </div>
@@ -106,14 +107,13 @@ export default function QuestionDetailPage({ params }: { params: Promise<{ id: s
   return (
     <div className="w-full max-w-2xl mx-auto px-5 pt-6 pb-12 md:px-8 md:pt-10 md:pb-20">
       {/* Back button */}
-      <div className="flex items-center gap-3 mb-6">
+      <div className="mb-4">
         <button
           onClick={() => router.back()}
           className="p-2.5 active:bg-muted rounded-lg transition-colors"
         >
           <ArrowLeftIcon className="w-6 h-6 text-foreground" />
         </button>
-        <h1 className="text-2xl font-bold text-foreground">질문 상세</h1>
       </div>
 
       <div className="space-y-8">
@@ -125,7 +125,6 @@ export default function QuestionDetailPage({ params }: { params: Promise<{ id: s
         showResults={hasVoted}
         selectedOption={userVote ?? undefined}
         isLoading={loadingId === question.id}
-        isToday={question.isToday}
         showDate={true}
         hasVoted={hasVoted}
         hideVoteAfterMessage={true}

--- a/app/(main)/questions/[id]/page.tsx
+++ b/app/(main)/questions/[id]/page.tsx
@@ -4,7 +4,6 @@ import { use, useState, useEffect } from "react"
 import { useRouter } from "next/navigation"
 import { ArrowLeftIcon, ExclamationTriangleIcon } from "@heroicons/react/24/outline"
 import { QuestionCard } from "@/components/question-card"
-import { VotingResults } from "@/components/voting-results"
 import { CommentSection } from "@/components/comment-section"
 import { LoadingSkeleton } from "@/components/loading-skeleton"
 import { useQuestionsContext } from "@/contexts/questions-context"
@@ -106,38 +105,81 @@ export default function QuestionDetailPage({ params }: { params: Promise<{ id: s
 
   return (
     <div className="w-full max-w-2xl mx-auto px-5 pt-6 pb-12 md:px-8 md:pt-10 md:pb-20">
-      {/* Back button */}
-      <div className="mb-4">
+      {/* Header */}
+      <div className="relative flex items-center justify-center mb-6">
         <button
           onClick={() => router.back()}
-          className="p-2.5 active:bg-muted rounded-lg transition-colors"
+          className="absolute left-0 p-2.5 active:bg-muted rounded-lg transition-colors"
         >
           <ArrowLeftIcon className="w-6 h-6 text-foreground" />
         </button>
+        <span className="text-lg font-medium text-muted-foreground">{question.date}</span>
       </div>
 
       <div className="space-y-8">
+        {/* Title & Description */}
+        <div className="space-y-3">
+          <h1 className="text-2xl md:text-3xl font-bold text-foreground leading-tight">
+            {question.title}
+          </h1>
+          {question.description && (
+            <p className="text-base md:text-lg text-muted-foreground leading-relaxed">
+              {question.description}
+            </p>
+          )}
+        </div>
 
-      {/* Question Card */}
-      <QuestionCard
-        question={question}
-        onVote={(optionIndex) => castVote(question.id, optionIndex)}
-        showResults={hasVoted}
-        selectedOption={userVote ?? undefined}
-        isLoading={loadingId === question.id}
-        showDate={true}
-        hasVoted={hasVoted}
-        hideVoteAfterMessage={true}
-        showDescription={true}
-      />
+        {/* VS Vote Options */}
+        <div className="relative">
+          <div className="space-y-3">
+            {question.options.map((option, i) => {
+              const isSelected = userVote === i
 
-      {/* Show results and comments only if user has voted */}
-      {hasVoted && (
-        <>
-          <VotingResults question={question} />
+              return (
+                <button
+                  key={i}
+                  onClick={() => !hasVoted && question.status !== "CLOSED" && castVote(question.id, i)}
+                  disabled={loadingId === question.id || question.status === "CLOSED"}
+                  className={`w-full p-5 md:p-6 rounded-xl border-2 transition-all font-medium text-base md:text-lg relative overflow-hidden ${
+                    question.status === "CLOSED"
+                      ? "border-border bg-muted text-foreground cursor-not-allowed opacity-60"
+                      : hasVoted
+                        ? "border-primary/30 text-foreground"
+                        : "border-border text-foreground active:border-primary/60 active:bg-primary/5"
+                  } ${loadingId === question.id ? "opacity-60 cursor-wait" : ""}`}
+                >
+                  {/* 배경 채우기 - 비율만큼 */}
+                  {hasVoted && (
+                    <div className="absolute top-0 left-0 bottom-0 bg-primary/15 transition-all duration-500 rounded-l-lg"
+                      style={{ width: `${question.votes[i]}%` }}
+                    />
+                  )}
+                  <div className="relative flex items-center justify-between">
+                    <span className="leading-relaxed">{option}</span>
+                    {hasVoted && (
+                      <span className="text-lg font-bold text-foreground">
+                        {question.votes[i].toFixed(1)}%
+                      </span>
+                    )}
+                  </div>
+                </button>
+              )
+            })}
+          </div>
+
+        </div>
+
+        {/* Participation info */}
+        <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
+          <span>{question.totalVotes.toLocaleString()}명 참여</span>
+          <span>·</span>
+          <span>댓글 {question.commentCount}개</span>
+        </div>
+
+        {/* Show comments only if user has voted */}
+        {hasVoted && (
           <CommentSection questionId={question.id} commentCount={question.commentCount} />
-        </>
-      )}
+        )}
       </div>
     </div>
   )

--- a/app/(main)/questions/page.tsx
+++ b/app/(main)/questions/page.tsx
@@ -4,9 +4,10 @@ import { useEffect, useRef, useCallback } from "react"
 import { useRouter } from "next/navigation"
 import { QuestionCard } from "@/components/question-card"
 import { LoadingSkeleton } from "@/components/loading-skeleton"
+import { PullToRefresh } from "@/components/pull-to-refresh"
 import { useQuestionsContext } from "@/contexts/questions-context"
 import { useAuthContext } from "@/contexts/auth-context"
-import { QuestionMarkCircleIcon } from "@heroicons/react/24/outline"
+import { ChatBubbleOvalLeftEllipsisIcon } from "@heroicons/react/24/outline"
 
 export default function QuestionsPage() {
   const router = useRouter()
@@ -23,6 +24,8 @@ export default function QuestionsPage() {
     isLoading,
     hasMore,
     loadMore,
+    refreshQuestion,
+    refreshingId,
   } = useQuestionsContext()
 
   // 무한스크롤을 위한 observer ref
@@ -67,14 +70,17 @@ export default function QuestionsPage() {
     router.push(`/questions/${questionId}`)
   }
 
+  const handlePullRefresh = useCallback(async () => {
+    await Promise.all([fetchTodayQuestion(), fetchPastQuestions()])
+  }, [fetchTodayQuestion, fetchPastQuestions])
+
   if (isLoading && allQuestions.length === 0) {
     return <LoadingSkeleton />
   }
 
   return (
-    <div className="w-full max-w-2xl mx-auto px-5 pt-6 pb-12 md:px-8 md:pt-10 md:pb-20">
-      <h1 className="text-2xl font-bold text-foreground mb-6">질문</h1>
-
+    <PullToRefresh onRefresh={handlePullRefresh}>
+      <div className="w-full max-w-2xl mx-auto px-5 pt-6 pb-12 md:px-8 md:pt-10 md:pb-20">
       <div className="space-y-5">
         {allQuestions.map((question) => {
           const hasVoted = hasUserVoted(question.id)
@@ -82,23 +88,25 @@ export default function QuestionsPage() {
           return (
             <div
               key={question.id}
-              onClick={() => handleQuestionClick(question.id)}
-              className={`rounded-lg bg-card cursor-pointer transition-all duration-200
-                hover:shadow-md hover:-translate-y-[1px]
+              className={`rounded-lg bg-card transition-all duration-200
                 ${
                   question.isToday
-                    ? "border-2 border-primary hover:border-primary"
-                    : "border border-border hover:border-foreground/60"
+                    ? "border-2 border-primary/60"
+                    : "border border-border"
                 }`}
             >
               <QuestionCard
                 question={question}
                 onVote={(optionIndex) => castVote(question.id, optionIndex)}
+                onRefresh={() => refreshQuestion(question.id)}
+                onDetailClick={() => handleQuestionClick(question.id)}
                 showResults={hasVoted}
                 selectedOption={getUserVote(question.id) ?? undefined}
                 isLoading={loadingId === question.id}
+                isRefreshing={refreshingId === question.id}
                 showDate={true}
                 hasVoted={hasVoted}
+                showDescription={true}
               />
             </div>
           )
@@ -110,7 +118,7 @@ export default function QuestionsPage() {
         <div ref={observerTarget} className="py-6 text-center">
           {isLoading && (
             <div className="inline-flex items-center gap-2 text-sm text-muted-foreground">
-              <div className="w-4 h-4 border-2 border-primary border-t-transparent rounded-full animate-spin" />
+              <div className="w-4 h-4 border-2 border-primary/60 border-t-transparent rounded-full animate-spin" />
               <span>로딩 중...</span>
             </div>
           )}
@@ -118,19 +126,18 @@ export default function QuestionsPage() {
       )}
 
       {allQuestions.length === 0 && !isLoading && (
-        <div className="text-center py-16 space-y-4">
-          <div className="flex justify-center">
-            <div className="w-16 h-16 bg-primary/10 rounded-full flex items-center justify-center">
-              <QuestionMarkCircleIcon className="w-8 h-8 text-primary/60" />
-            </div>
-          </div>
-          <div className="space-y-1">
-            <p className="text-base font-medium text-foreground">아직 질문이 없습니다</p>
-            <p className="text-sm text-muted-foreground">매일 새로운 질문이 올라옵니다</p>
-          </div>
+        <div className="flex flex-col items-center pt-65">
+          <ChatBubbleOvalLeftEllipsisIcon className="w-16 h-16 text-primary/60 mb-4" />
+          <p className="text-[15px] text-muted-foreground mb-1">
+            질문이 곧 도착해요
+          </p>
+          <p className="text-[13px] text-muted-foreground/90">
+            첫 번째 질문을 준비하고 있어요
+          </p>
         </div>
       )}
 
     </div>
+    </PullToRefresh>
   )
 }

--- a/app/(main)/questions/page.tsx
+++ b/app/(main)/questions/page.tsx
@@ -1,17 +1,21 @@
 "use client"
 
-import { useEffect, useRef, useCallback } from "react"
+import { useEffect, useRef, useCallback, useState } from "react"
 import { useRouter } from "next/navigation"
 import { QuestionCard } from "@/components/question-card"
 import { LoadingSkeleton } from "@/components/loading-skeleton"
 import { PullToRefresh } from "@/components/pull-to-refresh"
 import { useQuestionsContext } from "@/contexts/questions-context"
 import { useAuthContext } from "@/contexts/auth-context"
-import { ChatBubbleOvalLeftEllipsisIcon } from "@heroicons/react/24/outline"
+import { ChatBubbleOvalLeftEllipsisIcon, TicketIcon } from "@heroicons/react/24/outline"
+import type { Question } from "@/types/entities"
 
 export default function QuestionsPage() {
   const router = useRouter()
   const { isLoading: authLoading } = useAuthContext()
+  const [showTicketModal, setShowTicketModal] = useState(false)
+  const [selectedClosedQuestion, setSelectedClosedQuestion] = useState<Question | null>(null)
+  const ticketCount = 1 // TODO: 실제 열람권 개수 연동
   const {
     todayQuestion,
     pastQuestions,
@@ -66,8 +70,25 @@ export default function QuestionsPage() {
     ? [todayQuestion, ...pastQuestions]
     : pastQuestions
 
-  const handleQuestionClick = (questionId: string) => {
-    router.push(`/questions/${questionId}`)
+  const handleQuestionClick = (question: Question) => {
+    const hasVoted = hasUserVoted(question.id)
+    const isClosedWithoutVote = question.status === "CLOSED" && !hasVoted
+
+    if (isClosedWithoutVote) {
+      setSelectedClosedQuestion(question)
+      setShowTicketModal(true)
+    } else {
+      router.push(`/questions/${question.id}`)
+    }
+  }
+
+  const handleUseTicket = () => {
+    if (selectedClosedQuestion && ticketCount > 0) {
+      // TODO: 열람권 사용 API 호출
+      router.push(`/questions/${selectedClosedQuestion.id}`)
+    }
+    setShowTicketModal(false)
+    setSelectedClosedQuestion(null)
   }
 
   const handlePullRefresh = useCallback(async () => {
@@ -81,6 +102,9 @@ export default function QuestionsPage() {
   return (
     <PullToRefresh onRefresh={handlePullRefresh}>
       <div className="w-full max-w-2xl mx-auto px-5 pt-6 pb-12 md:px-8 md:pt-10 md:pb-20">
+      {/* Header */}
+      <h1 className="text-2xl text-foreground text-center mb-5">질문</h1>
+
       <div className="space-y-5">
         {allQuestions.map((question) => {
           const hasVoted = hasUserVoted(question.id)
@@ -99,7 +123,7 @@ export default function QuestionsPage() {
                 question={question}
                 onVote={(optionIndex) => castVote(question.id, optionIndex)}
                 onRefresh={() => refreshQuestion(question.id)}
-                onDetailClick={() => handleQuestionClick(question.id)}
+                onDetailClick={() => handleQuestionClick(question)}
                 showResults={hasVoted}
                 selectedOption={getUserVote(question.id) ?? undefined}
                 isLoading={loadingId === question.id}
@@ -138,6 +162,62 @@ export default function QuestionsPage() {
       )}
 
     </div>
+
+      {/* 열람권 사용 확인 모달 */}
+      {showTicketModal && selectedClosedQuestion && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
+          {/* 배경 오버레이 */}
+          <div
+            className="absolute inset-0 bg-black/40"
+            onClick={() => {
+              setShowTicketModal(false)
+              setSelectedClosedQuestion(null)
+            }}
+          />
+
+          {/* 모달 */}
+          <div className="relative bg-card rounded-2xl border border-border p-6 mx-5 max-w-sm w-full shadow-xl">
+            <div className="flex flex-col items-center text-center">
+              <div className="w-14 h-14 bg-primary/10 rounded-full flex items-center justify-center mb-4">
+                <TicketIcon className="w-7 h-7 text-primary" />
+              </div>
+
+              <h3 className="text-lg font-semibold text-foreground mb-2">
+                열람권을 사용하시겠어요?
+              </h3>
+              <p className="text-sm text-muted-foreground mb-1">
+                종료된 질문의 결과를 확인할 수 있어요
+              </p>
+              <p className="text-sm text-muted-foreground mb-6">
+                보유 열람권: <span className="font-semibold text-primary">{ticketCount}개</span>
+              </p>
+
+              <div className="flex flex-col gap-2 w-full">
+                <button
+                  onClick={handleUseTicket}
+                  disabled={ticketCount === 0}
+                  className={`w-full py-3 px-4 rounded-xl font-medium text-[15px] active:scale-95 transition-transform ${
+                    ticketCount > 0
+                      ? "bg-primary/60 text-white"
+                      : "bg-muted text-muted-foreground cursor-not-allowed"
+                  }`}
+                >
+                  {ticketCount > 0 ? "열람권 사용하기" : "열람권이 없어요"}
+                </button>
+                <button
+                  onClick={() => {
+                    setShowTicketModal(false)
+                    setSelectedClosedQuestion(null)
+                  }}
+                  className="w-full py-3 px-4 bg-muted text-muted-foreground rounded-xl font-medium text-[15px] active:scale-95 transition-transform"
+                >
+                  취소
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
     </PullToRefresh>
   )
 }

--- a/app/(main)/settings/page.tsx
+++ b/app/(main)/settings/page.tsx
@@ -6,6 +6,7 @@ import { useState, useEffect } from "react"
 import { useAuthContext } from "@/contexts/auth-context"
 import { useRouter } from "next/navigation"
 import { updateNotificationSettings } from "@/lib/notification-api"
+import { toast } from "sonner"
 
 export default function SettingsPage() {
   const { logout, deleteAccount, isAuthenticated, user } = useAuthContext()
@@ -35,7 +36,7 @@ export default function SettingsPage() {
       console.error("알림 설정 업데이트 실패:", errorMessage, error)
       // 실패 시 원래 상태로 복구
       setNotificationsEnabled(!enabled)
-      alert(`알림 설정 업데이트에 실패했습니다: ${errorMessage}`)
+      toast.error(errorMessage)
     } finally {
       setIsUpdating(false)
     }
@@ -48,7 +49,7 @@ export default function SettingsPage() {
     } catch (error: any) {
       const errorMessage = error?.message || "로그아웃에 실패했습니다"
       console.error("로그아웃 실패:", errorMessage, error)
-      alert(`로그아웃에 실패했습니다: ${errorMessage}`)
+      toast.error(errorMessage)
     }
   }
 
@@ -60,7 +61,7 @@ export default function SettingsPage() {
     } catch (error: any) {
       const errorMessage = error?.message || "회원 탈퇴에 실패했습니다"
       console.error("회원 탈퇴 실패:", errorMessage, error)
-      alert(`회원 탈퇴에 실패했습니다: ${errorMessage}`)
+      toast.error(errorMessage)
     } finally {
       setIsDeleting(false)
       setShowDeleteModal(false)

--- a/app/(main)/settings/page.tsx
+++ b/app/(main)/settings/page.tsx
@@ -70,89 +70,75 @@ export default function SettingsPage() {
 
   return (
     <div className="w-full max-w-2xl mx-auto px-5 pt-6 pb-12 md:px-8 md:pt-10 md:pb-20">
-      {/* Back button */}
-      <div className="mb-4">
+      {/* Header */}
+      <div className="relative flex items-center justify-center mb-4">
         <button
           onClick={() => router.back()}
-          className="p-2.5 active:bg-muted rounded-lg transition-colors"
+          className="absolute left-0 p-2.5 active:bg-muted rounded-lg transition-colors"
           aria-label="뒤로가기"
         >
           <ArrowLeftIcon className="w-6 h-6 text-foreground" />
         </button>
+        <h1 className="text-lg font-semibold text-foreground">환경설정</h1>
       </div>
 
-      <div className="space-y-8">
-      {/* Login Info */}
-      {isAuthenticated && (
-        <div className="bg-card rounded-lg border border-border p-6 space-y-5">
-          <div className="space-y-1.5">
-            <h3 className="text-lg md:text-xl font-semibold text-foreground">로그인 정보</h3>
-            <p className="text-sm text-muted-foreground">현재 연결된 계정</p>
+      <div className="divide-y divide-border">
+        {/* Login Info */}
+        {isAuthenticated && (
+          <div className="py-6 space-y-3">
+            <div className="space-y-1">
+              <h3 className="text-sm font-medium text-muted-foreground">로그인 정보</h3>
+            </div>
+            <p className="text-base font-medium text-foreground">
+              {user?.email || "Google 계정으로 로그인됨"}
+            </p>
           </div>
-          <div className="p-4 bg-muted/50 rounded-lg">
-            {user?.email ? (
-              <p className="text-sm md:text-base font-medium text-foreground">{user.email}</p>
-            ) : (
-              <p className="text-sm md:text-base text-muted-foreground">Google 계정으로 로그인됨</p>
-            )}
+        )}
+
+        {/* Notification Settings */}
+        <div className="py-6 space-y-4">
+          <h3 className="text-sm font-medium text-muted-foreground">알림 설정</h3>
+          <div className="flex items-center justify-between">
+            <div className="space-y-0.5 flex-1 pr-4">
+              <p className="text-base text-foreground">오늘의 질문</p>
+              <p className="text-sm text-muted-foreground">매일 새 질문이 올라오면 알려드려요</p>
+            </div>
+            <Switch
+              checked={notificationsEnabled}
+              onCheckedChange={handleNotificationToggle}
+              disabled={isUpdating}
+            />
           </div>
         </div>
-      )}
 
-      {/* Notification Settings */}
-      <div className="bg-card rounded-lg border border-border p-6 space-y-5">
-        <div className="space-y-1.5">
-          <h3 className="text-lg md:text-xl font-semibold text-foreground">알림 설정</h3>
-        </div>
+        {/* Account Actions */}
+        {isAuthenticated && (
+          <div className="py-6 space-y-2">
+            <h3 className="text-sm font-medium text-muted-foreground mb-4">계정 관리</h3>
 
-        <div className="flex items-center justify-between p-4 bg-muted/50 rounded-lg">
-          <div className="space-y-1 flex-1 pr-4">
-            <p className="font-medium text-sm md:text-base text-foreground">오늘의 질문</p>
-            <p className="text-xs md:text-sm text-muted-foreground leading-relaxed">매일 새 질문이 올라오면 알려드립니다</p>
+            <button
+              onClick={handleLogout}
+              className="w-full text-left py-3 text-destructive transition-colors flex items-center gap-3 active:opacity-70"
+            >
+              <ArrowLeftStartOnRectangleIcon className="w-5 h-5" />
+              <span className="text-base">로그아웃</span>
+            </button>
+
+            <button
+              onClick={() => setShowDeleteModal(true)}
+              className="w-full text-left py-3 text-destructive transition-colors flex items-center gap-3 active:opacity-70"
+            >
+              <TrashIcon className="w-5 h-5" />
+              <span className="text-base">회원 탈퇴</span>
+            </button>
           </div>
-          <Switch
-            checked={notificationsEnabled}
-            onCheckedChange={handleNotificationToggle}
-            disabled={isUpdating}
-          />
-        </div>
+        )}
 
-        <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
-          <p className="text-sm md:text-base text-blue-900 leading-relaxed">알림을 비활성화해도 앱에서 언제든지 새로운 질문에 참여할 수 있습니다.</p>
-        </div>
-      </div>
-
-      {/* Account Actions */}
-      {isAuthenticated && (
-        <div className="bg-card rounded-lg border border-border p-6 space-y-3">
-          <div className="space-y-1.5 mb-4">
-            <h3 className="text-lg md:text-xl font-semibold text-foreground">계정 관리</h3>
-            <p className="text-sm text-muted-foreground">로그아웃 및 탈퇴</p>
+        {!isAuthenticated && (
+          <div className="py-8 text-center">
+            <p className="text-base text-muted-foreground">로그인되지 않았습니다</p>
           </div>
-
-          <button
-            onClick={handleLogout}
-            className="w-full text-left p-4 active:bg-destructive/10 text-destructive rounded-lg transition-colors flex items-center gap-3"
-          >
-            <ArrowLeftStartOnRectangleIcon className="w-5 h-5 md:w-6 md:h-6" />
-            <span className="text-sm md:text-base font-medium">로그아웃</span>
-          </button>
-
-          <button
-            onClick={() => setShowDeleteModal(true)}
-            className="w-full text-left p-4 rounded-lg transition-colors flex items-center gap-3 active:bg-destructive/10 text-destructive"
-          >
-            <TrashIcon className="w-5 h-5 md:w-6 md:h-6" />
-            <span className="text-sm md:text-base font-medium">회원 탈퇴</span>
-          </button>
-        </div>
-      )}
-
-      {!isAuthenticated && (
-        <div className="bg-card rounded-lg border border-border p-8 text-center">
-          <p className="text-sm md:text-base text-muted-foreground">로그인되지 않았습니다</p>
-        </div>
-      )}
+        )}
       </div>
 
       {/* 회원탈퇴 확인 모달 */}

--- a/app/(main)/settings/page.tsx
+++ b/app/(main)/settings/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { ArrowLeftIcon, ArrowLeftStartOnRectangleIcon, TrashIcon } from "@heroicons/react/24/outline"
+import { ArrowLeftIcon, ArrowLeftStartOnRectangleIcon, TrashIcon, ArrowRightOnRectangleIcon } from "@heroicons/react/24/outline"
 import { Switch } from "@/components/ui/switch"
 import { useState, useEffect } from "react"
 import { useAuthContext } from "@/contexts/auth-context"
@@ -10,7 +10,8 @@ import { updateNotificationSettings } from "@/lib/notification-api"
 export default function SettingsPage() {
   const { logout, deleteAccount, isAuthenticated, user } = useAuthContext()
   const router = useRouter()
-  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
+  const [showDeleteModal, setShowDeleteModal] = useState(false)
+  const [isDeleting, setIsDeleting] = useState(false)
   const [notificationsEnabled, setNotificationsEnabled] = useState(false)
   const [isUpdating, setIsUpdating] = useState(false)
 
@@ -52,11 +53,7 @@ export default function SettingsPage() {
   }
 
   const handleDeleteAccount = async () => {
-    if (!showDeleteConfirm) {
-      setShowDeleteConfirm(true)
-      return
-    }
-
+    setIsDeleting(true)
     try {
       await deleteAccount()
       router.push("/")
@@ -64,13 +61,16 @@ export default function SettingsPage() {
       const errorMessage = error?.message || "회원 탈퇴에 실패했습니다"
       console.error("회원 탈퇴 실패:", errorMessage, error)
       alert(`회원 탈퇴에 실패했습니다: ${errorMessage}`)
+    } finally {
+      setIsDeleting(false)
+      setShowDeleteModal(false)
     }
   }
 
   return (
     <div className="w-full max-w-2xl mx-auto px-5 pt-6 pb-12 md:px-8 md:pt-10 md:pb-20">
-      {/* Header with back button */}
-      <div className="flex items-center gap-3 mb-6">
+      {/* Back button */}
+      <div className="mb-4">
         <button
           onClick={() => router.back()}
           className="p-2.5 active:bg-muted rounded-lg transition-colors"
@@ -78,7 +78,6 @@ export default function SettingsPage() {
         >
           <ArrowLeftIcon className="w-6 h-6 text-foreground" />
         </button>
-        <h1 className="text-2xl font-bold text-foreground">설정</h1>
       </div>
 
       <div className="space-y-8">
@@ -139,25 +138,12 @@ export default function SettingsPage() {
           </button>
 
           <button
-            onClick={handleDeleteAccount}
-            className={`w-full text-left p-4 rounded-lg transition-colors flex items-center gap-3 ${
-              showDeleteConfirm
-                ? "bg-red-600 text-white"
-                : "active:bg-destructive/10 text-destructive"
-            }`}
+            onClick={() => setShowDeleteModal(true)}
+            className="w-full text-left p-4 rounded-lg transition-colors flex items-center gap-3 active:bg-destructive/10 text-destructive"
           >
             <TrashIcon className="w-5 h-5 md:w-6 md:h-6" />
-            <span className="text-sm md:text-base font-medium">{showDeleteConfirm ? "탈퇴하시겠습니까?" : "회원 탈퇴"}</span>
+            <span className="text-sm md:text-base font-medium">회원 탈퇴</span>
           </button>
-
-          {showDeleteConfirm && (
-            <button
-              onClick={() => setShowDeleteConfirm(false)}
-              className="w-full text-left p-4 active:bg-muted rounded-lg transition-colors text-sm md:text-base text-muted-foreground"
-            >
-              취소
-            </button>
-          )}
         </div>
       )}
 
@@ -167,6 +153,50 @@ export default function SettingsPage() {
         </div>
       )}
       </div>
+
+      {/* 회원탈퇴 확인 모달 */}
+      {showDeleteModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
+          {/* 배경 오버레이 */}
+          <div
+            className="absolute inset-0 bg-black/40"
+            onClick={() => !isDeleting && setShowDeleteModal(false)}
+          />
+
+          {/* 모달 */}
+          <div className="relative bg-card rounded-2xl border border-border p-6 mx-5 max-w-sm w-full shadow-xl">
+            <div className="flex flex-col items-center text-center">
+              <div className="w-14 h-14 bg-primary/10 rounded-full flex items-center justify-center mb-4">
+                <ArrowRightOnRectangleIcon className="w-7 h-7 text-primary" />
+              </div>
+
+              <h3 className="text-lg font-semibold text-foreground mb-2">
+                잠깐, 정말 떠나시나요?
+              </h3>
+              <p className="text-sm text-muted-foreground mb-6">
+                지금까지의 투표 기록과 댓글이 모두 사라져요
+              </p>
+
+              <div className="flex flex-col gap-2 w-full">
+                <button
+                  onClick={() => setShowDeleteModal(false)}
+                  disabled={isDeleting}
+                  className="w-full py-3 px-4 bg-primary/60 text-white rounded-xl font-medium text-[15px] active:scale-95 transition-transform disabled:opacity-50"
+                >
+                  계속 함께하기
+                </button>
+                <button
+                  onClick={handleDeleteAccount}
+                  disabled={isDeleting}
+                  className="w-full py-3 px-4 bg-muted text-muted-foreground rounded-xl font-medium text-[15px] active:scale-95 transition-transform disabled:opacity-50"
+                >
+                  {isDeleting ? "탈퇴 중..." : "그래도 탈퇴할게요"}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/components/activity-chart.tsx
+++ b/components/activity-chart.tsx
@@ -1,27 +1,34 @@
 "use client"
 
+import { FireIcon as FireIconSolid } from "@heroicons/react/24/solid"
+import { FireIcon as FireIconOutline } from "@heroicons/react/24/outline"
+
 interface ActivityChartProps {
-  data: Array<{ date: string; count: number }>
-  maxValue?: number
+  data: Array<{ date: string; participated: boolean; isToday?: boolean }>
 }
 
-export function ActivityChart({ data, maxValue = 5 }: ActivityChartProps) {
-  const max = Math.max(maxValue, ...data.map((d) => d.count))
-
+export function ActivityChart({ data }: ActivityChartProps) {
   return (
-    <div className="space-y-3">
-      <div className="flex items-end justify-between gap-1 h-24">
-        {data.map((item, i) => (
-          <div key={i} className="flex-1 flex flex-col items-center gap-2">
-            <div
-              className="w-full bg-gradient-to-t from-primary to-primary/50 rounded-t transition-all hover:from-primary/90"
-              style={{ height: `${(item.count / max) * 100}%`, minHeight: item.count > 0 ? "4px" : "0px" }}
-              title={`${item.date}: ${item.count}회`}
-            />
-            <span className="text-xs text-muted-foreground">{item.date}</span>
+    <div className="flex items-center justify-between">
+      {data.map((item, i) => (
+        <div key={i} className="flex flex-col items-center gap-1.5">
+          <div
+            className="w-10 h-10 flex items-center justify-center"
+            title={`${item.date}: ${item.isToday ? "오늘" : ""} ${item.participated ? "참여" : "미참여"}`}
+          >
+            {item.participated ? (
+              <FireIconSolid className="w-7 h-7 text-orange-500" />
+            ) : item.isToday ? (
+              <div className="w-8 h-8 rounded-full border-2 border-dashed border-primary/40 flex items-center justify-center">
+                <span className="text-xs text-muted-foreground">?</span>
+              </div>
+            ) : (
+              <FireIconOutline className="w-7 h-7 text-muted-foreground/30" />
+            )}
           </div>
-        ))}
-      </div>
+          <span className="text-xs text-muted-foreground">{item.date}</span>
+        </div>
+      ))}
     </div>
   )
 }

--- a/components/client-providers.tsx
+++ b/components/client-providers.tsx
@@ -2,11 +2,15 @@
 
 import { QuestionsProvider } from "@/contexts/questions-context"
 import { AuthProvider } from "@/contexts/auth-context"
+import { Toaster } from "sonner"
 
 export function ClientProviders({ children }: { children: React.ReactNode }) {
   return (
     <AuthProvider>
-      <QuestionsProvider>{children}</QuestionsProvider>
+      <QuestionsProvider>
+        {children}
+        <Toaster position="bottom-center" richColors />
+      </QuestionsProvider>
     </AuthProvider>
   )
 }

--- a/components/comment-item.tsx
+++ b/components/comment-item.tsx
@@ -1,7 +1,8 @@
 "use client"
 
-import { HeartIcon, ChatBubbleLeftIcon } from "@heroicons/react/24/outline"
-import { HeartIcon as HeartSolidIcon, UserCircleIcon } from "@heroicons/react/24/solid"
+import { useState, useRef, useEffect } from "react"
+import { UserGroupIcon, ScaleIcon, RocketLaunchIcon, HandThumbUpIcon, ChatBubbleOvalLeftIcon, EllipsisVerticalIcon } from "@heroicons/react/24/outline"
+import { HandThumbUpIcon as HandThumbUpSolidIcon } from "@heroicons/react/24/solid"
 
 interface CommentItemProps {
   id: string
@@ -11,8 +12,12 @@ interface CommentItemProps {
   likes: number
   isReply?: boolean
   userLiked?: boolean
+  isOwn?: boolean
   onReply?: (commentId: string) => void
   onLike?: (commentId: string) => void
+  onDelete?: (commentId: string) => void
+  onBlock?: (commentId: string) => void
+  onReport?: (commentId: string) => void
 }
 
 export function CommentItem({
@@ -23,52 +28,128 @@ export function CommentItem({
   likes,
   isReply = false,
   userLiked = false,
+  isOwn = false,
   onReply,
   onLike,
+  onDelete,
+  onBlock,
+  onReport,
 }: CommentItemProps) {
+  const [showMenu, setShowMenu] = useState(false)
+  const menuRef = useRef<HTMLDivElement>(null)
+
+  // 프로필 아이콘 3가지 (author 기반으로 결정)
+  const profileIcons = [UserGroupIcon, ScaleIcon, RocketLaunchIcon]
+  const iconIndex = author.charCodeAt(0) % 3
+  const ProfileIcon = profileIcons[iconIndex]
+
+  // 메뉴 외부 클릭 시 닫기
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        setShowMenu(false)
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside)
+    return () => document.removeEventListener("mousedown", handleClickOutside)
+  }, [])
+
   return (
-    <div className={`${isReply ? "ml-6 border-l-2 border-muted pl-4" : ""}`}>
-      <div className="flex gap-3">
-        {/* Avatar placeholder */}
-        <UserCircleIcon className="w-10 h-10 text-primary/60 flex-shrink-0" />
-
-        <div className="flex-1 space-y-2">
-          {/* Header with author and date */}
-          <div className="flex items-center gap-2.5">
-            <p className="text-sm md:text-base font-semibold text-primary">{author}</p>
-            <p className="text-xs md:text-sm text-muted-foreground">{date}</p>
+    <div className={`${isReply ? "ml-6 pl-3 border-l-2 border-muted" : ""}`}>
+      {/* Header - 프로필 아이콘, 작성자, 액션 버튼들 */}
+      <div className="flex items-center justify-between mb-1">
+        <div className="flex items-center gap-1.5">
+          <div className="w-5 h-5 rounded-full flex items-center justify-center bg-primary/20 text-primary">
+            <ProfileIcon className="w-3 h-3" />
           </div>
+          <span className="text-[15px] font-medium text-foreground">{author}</span>
+        </div>
 
-          {/* Comment text */}
-          <p className="text-sm md:text-base text-foreground leading-relaxed">{text}</p>
-
-          {/* Actions */}
-          <div className="flex items-center gap-4 pt-1">
+        {/* 우측 액션 버튼들 */}
+        <div className="flex items-center gap-1">
+          <button
+            onClick={() => onLike?.(id)}
+            className={`p-1 ${userLiked ? "text-primary/60" : "text-muted-foreground"}`}
+          >
+            {userLiked ? (
+              <HandThumbUpSolidIcon className="w-4 h-4" />
+            ) : (
+              <HandThumbUpIcon className="w-4 h-4" />
+            )}
+          </button>
+          {!isReply && onReply && (
             <button
-              onClick={() => onLike?.(id)}
-              className={`flex items-center gap-1.5 text-xs md:text-sm transition-colors p-1.5 rounded active:bg-muted ${
-                userLiked ? "text-red-500" : "text-muted-foreground active:text-foreground"
-              }`}
+              onClick={() => onReply(id)}
+              className="p-1 text-muted-foreground"
             >
-              {userLiked ? (
-                <HeartSolidIcon className="w-4 h-4 md:w-5 md:h-5 text-red-500" />
-              ) : (
-                <HeartIcon className="w-4 h-4 md:w-5 md:h-5" />
-              )}
-              <span className="font-medium">{likes > 0 ? likes : ""}</span>
+              <ChatBubbleOvalLeftIcon className="w-4 h-4" />
+            </button>
+          )}
+          <div className="relative" ref={menuRef}>
+            <button
+              onClick={() => setShowMenu(!showMenu)}
+              className="p-1 text-muted-foreground"
+            >
+              <EllipsisVerticalIcon className="w-4 h-4" />
             </button>
 
-            {!isReply && onReply && (
-              <button
-                onClick={() => onReply(id)}
-                className="flex items-center gap-1.5 text-xs md:text-sm text-muted-foreground active:text-foreground transition-colors p-1.5 rounded active:bg-muted"
-              >
-                <ChatBubbleLeftIcon className="w-4 h-4 md:w-5 md:h-5" />
-                <span className="font-medium">답글</span>
-              </button>
+            {/* 드롭다운 메뉴 */}
+            {showMenu && (
+              <div className="absolute right-0 top-full mt-1 bg-card border border-border rounded-lg shadow-lg py-1 min-w-[100px] z-10">
+                {isOwn ? (
+                  <button
+                    onClick={() => {
+                      onDelete?.(id)
+                      setShowMenu(false)
+                    }}
+                    className="w-full px-3 py-2 text-left text-sm text-destructive hover:bg-muted"
+                  >
+                    삭제
+                  </button>
+                ) : (
+                  <>
+                    <button
+                      onClick={() => {
+                        onBlock?.(id)
+                        setShowMenu(false)
+                      }}
+                      className="w-full px-3 py-2 text-left text-sm text-foreground hover:bg-muted"
+                    >
+                      차단
+                    </button>
+                    <button
+                      onClick={() => {
+                        onReport?.(id)
+                        setShowMenu(false)
+                      }}
+                      className="w-full px-3 py-2 text-left text-sm text-foreground hover:bg-muted"
+                    >
+                      신고
+                    </button>
+                  </>
+                )}
+              </div>
             )}
           </div>
         </div>
+      </div>
+
+      {/* 댓글 내용 */}
+      <p className="text-base text-foreground leading-relaxed mb-1.5 pl-[26px]">{text}</p>
+
+      {/* 날짜 & 좋아요 수 */}
+      <div className="flex items-center gap-2 pl-[26px]">
+        <span className="text-sm text-muted-foreground">{date}</span>
+        {likes > 0 && (
+          <>
+            {userLiked ? (
+              <HandThumbUpSolidIcon className="w-3 h-3 text-primary/60" />
+            ) : (
+              <HandThumbUpIcon className="w-3 h-3 text-muted-foreground" />
+            )}
+            <span className={`text-sm ${userLiked ? "text-primary/60" : "text-muted-foreground"}`}>{likes}</span>
+          </>
+        )}
       </div>
     </div>
   )

--- a/components/comment-section.tsx
+++ b/components/comment-section.tsx
@@ -1,7 +1,6 @@
 "use client"
 
-import { ChatBubbleLeftIcon } from "@heroicons/react/24/outline"
-import { Button } from "@/components/ui/button"
+import { PaperAirplaneIcon } from "@heroicons/react/24/solid"
 import { CommentItem } from "@/components/comment-item"
 import { useComments } from "@/hooks/use-comments"
 
@@ -22,109 +21,138 @@ export function CommentSection({ questionId, commentCount }: CommentSectionProps
     setReplyText,
     addReply,
     toggleLike,
+    deleteComment,
+    blockUser,
+    reportComment,
   } = useComments(questionId)
 
   const handleSubmitComment = () => {
-    addComment(newCommentText)
+    if (newCommentText.trim()) {
+      addComment(newCommentText)
+    }
   }
 
   const handleSubmitReply = (parentId: string) => {
-    addReply(parentId, replyText)
+    if (replyText.trim()) {
+      addReply(parentId, replyText)
+    }
   }
 
   return (
-    <div className="bg-card rounded-lg border border-border p-6 space-y-5">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <h3 className="text-lg md:text-xl font-semibold text-foreground flex items-center gap-2.5">
-          <ChatBubbleLeftIcon className="w-5 h-5 md:w-6 md:h-6 text-primary" />
-          소통의 장
-        </h3>
-        <span className="text-sm md:text-base text-muted-foreground font-medium">{commentCount}개</span>
-      </div>
+    <>
+      <div className="space-y-4 pb-32">
+        {/* 댓글 목록 */}
+        <div className="space-y-0">
+          {comments.length === 0 ? (
+            <p className="text-sm text-muted-foreground text-center py-8">
+              첫 번째 댓글을 남겨보세요
+            </p>
+          ) : (
+            comments.map((comment, index) => (
+              <div key={comment.id}>
+                {/* 댓글 구분선 */}
+                {index > 0 && <div className="border-t border-border my-3" />}
 
-      {/* Comments list */}
-      <div className="space-y-4 max-h-96 overflow-y-auto">
-        {comments.map((comment) => (
-          <div key={comment.id} className="space-y-3">
-            <CommentItem
-              id={comment.id}
-              author={comment.author}
-              date={comment.date}
-              text={comment.text}
-              likes={comment.likes}
-              userLiked={comment.userLiked}
-              onReply={() => setReplyingTo(comment.id)}
-              onLike={() => toggleLike(comment.id)}
-            />
-
-            {/* Replies */}
-            {comment.replies.length > 0 && (
-              <div className="space-y-3">
-                {comment.replies.map((reply) => (
+                <div className="py-2">
                   <CommentItem
-                    key={reply.id}
-                    id={reply.id}
-                    author={reply.author}
-                    date={reply.date}
-                    text={reply.text}
-                    likes={reply.likes}
-                    isReply={true}
-                    userLiked={reply.userLiked}
-                    onLike={() => toggleLike(reply.id)}
+                    id={comment.id}
+                    author={comment.author}
+                    date={comment.date}
+                    text={comment.text}
+                    likes={comment.likes}
+                    userLiked={comment.userLiked}
+                    isOwn={comment.author === "즐거운펭귄"}
+                    onReply={() => setReplyingTo(replyingTo === comment.id ? null : comment.id)}
+                    onLike={() => toggleLike(comment.id)}
+                    onDelete={() => deleteComment(comment.id)}
+                    onBlock={() => blockUser(comment.id)}
+                    onReport={() => reportComment(comment.id)}
                   />
-                ))}
-              </div>
-            )}
 
-            {/* Reply input */}
-            {replyingTo === comment.id && (
-              <div className="ml-6 border-l-2 border-muted pl-4 py-2 space-y-3">
-                <textarea
-                  value={replyText}
-                  onChange={(e) => setReplyText(e.target.value)}
-                  placeholder="답글을 입력하세요..."
-                  className="w-full px-4 py-3 rounded-lg bg-muted text-foreground placeholder-muted-foreground text-sm md:text-base focus:outline-none focus:ring-2 focus:ring-primary resize-none leading-relaxed"
-                  rows={2}
-                />
-                <div className="flex gap-2 justify-end">
-                  <Button size="sm" variant="outline" onClick={() => setReplyingTo(null)}>
-                    취소
-                  </Button>
-                  <Button
-                    size="sm"
-                    className="bg-primary active:bg-primary/90 text-white"
-                    onClick={() => handleSubmitReply(comment.id)}
-                  >
-                    답글 등록
-                  </Button>
+                  {/* 대댓글 */}
+                  {comment.replies.length > 0 && (
+                    <div className="mt-3 space-y-3">
+                      {comment.replies.map((reply) => (
+                        <CommentItem
+                          key={reply.id}
+                          id={reply.id}
+                          author={reply.author}
+                          date={reply.date}
+                          text={reply.text}
+                          likes={reply.likes}
+                          isReply={true}
+                          userLiked={reply.userLiked}
+                          isOwn={reply.author === "즐거운펭귄"}
+                          onLike={() => toggleLike(reply.id)}
+                          onDelete={() => deleteComment(reply.id)}
+                          onBlock={() => blockUser(reply.id)}
+                          onReport={() => reportComment(reply.id)}
+                        />
+                      ))}
+                    </div>
+                  )}
+
+                  {/* 답글 입력 */}
+                  {replyingTo === comment.id && (
+                    <div className="mt-3 ml-6 pl-3 border-l-2 border-muted">
+                      <div className="flex items-center gap-2">
+                        <input
+                          type="text"
+                          value={replyText}
+                          onChange={(e) => setReplyText(e.target.value)}
+                          placeholder="답글을 입력하세요..."
+                          className="flex-1 px-3 py-2 bg-muted/50 rounded-lg text-sm text-foreground placeholder-muted-foreground focus:outline-none focus:bg-muted"
+                          onKeyDown={(e) => {
+                            if (e.key === "Enter") {
+                              handleSubmitReply(comment.id)
+                            } else if (e.key === "Escape") {
+                              setReplyingTo(null)
+                            }
+                          }}
+                          autoFocus
+                        />
+                        <button
+                          onClick={() => handleSubmitReply(comment.id)}
+                          disabled={!replyText.trim()}
+                          className="p-2 text-primary/60 disabled:opacity-40"
+                        >
+                          <PaperAirplaneIcon className="w-5 h-5" />
+                        </button>
+                      </div>
+                    </div>
+                  )}
                 </div>
               </div>
-            )}
-          </div>
-        ))}
-      </div>
-
-      {/* New comment input */}
-      <div className="flex flex-col gap-3 pt-4 border-t border-border">
-        <textarea
-          value={newCommentText}
-          onChange={(e) => setNewCommentText(e.target.value)}
-          placeholder="댓글을 입력하세요..."
-          className="w-full px-4 py-3 rounded-lg bg-muted text-foreground placeholder-muted-foreground text-sm md:text-base focus:outline-none focus:ring-2 focus:ring-primary resize-none leading-relaxed"
-          rows={3}
-        />
-        <div className="flex justify-end">
-          <Button
-            size="sm"
-            className="bg-primary active:bg-primary/90 text-white"
-            onClick={handleSubmitComment}
-            disabled={!newCommentText.trim()}
-          >
-            댓글 등록
-          </Button>
+            ))
+          )}
         </div>
       </div>
-    </div>
+
+      {/* 댓글 입력 - 하단 고정 (네비게이션 위) */}
+      <div className="fixed bottom-16 md:bottom-20 left-0 right-0 bg-background border-t border-border px-5 py-3 z-40">
+        <div className="max-w-2xl mx-auto flex items-center gap-2">
+          <input
+            type="text"
+            value={newCommentText}
+            onChange={(e) => setNewCommentText(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !e.shiftKey) {
+                e.preventDefault()
+                handleSubmitComment()
+              }
+            }}
+            placeholder="댓글을 입력하세요..."
+            className="flex-1 px-3 py-2.5 bg-muted/50 rounded-lg text-sm text-foreground placeholder-muted-foreground focus:outline-none focus:bg-muted"
+          />
+          <button
+            onClick={handleSubmitComment}
+            disabled={!newCommentText.trim()}
+            className="p-2 text-primary/60 disabled:opacity-40"
+          >
+            <PaperAirplaneIcon className="w-5 h-5" />
+          </button>
+        </div>
+      </div>
+    </>
   )
 }

--- a/components/initial-login-screen.tsx
+++ b/components/initial-login-screen.tsx
@@ -50,7 +50,7 @@ export function InitialLoginScreen({ onStartOnboarding }: InitialLoginScreenProp
           </Button>
         </div>
 
-        <p className="text-xs text-white/50 px-6 leading-relaxed">
+        <p className="text-xs text-white/90 px-6 leading-relaxed">
           서비스 이용약관 및 개인정보 처리방침에 동의합니다
         </p>
       </div>

--- a/components/onboarding-login-screen.tsx
+++ b/components/onboarding-login-screen.tsx
@@ -64,7 +64,7 @@ export function OnboardingLoginScreen() {
           </button>
         </div>
 
-        <p className="text-xs text-white/50 px-4">
+        <p className="text-xs text-white/90 px-4">
           로그인 시 서비스 이용약관 및 개인정보 처리방침에 동의하게 됩니다
         </p>
       </div>

--- a/components/pull-to-refresh.tsx
+++ b/components/pull-to-refresh.tsx
@@ -1,0 +1,94 @@
+"use client"
+
+import { useState, useRef, useCallback, type ReactNode } from "react"
+import { ArrowPathIcon } from "@heroicons/react/24/outline"
+
+interface PullToRefreshProps {
+  onRefresh: () => Promise<void>
+  children: ReactNode
+}
+
+export function PullToRefresh({ onRefresh, children }: PullToRefreshProps) {
+  const [pullDistance, setPullDistance] = useState(0)
+  const [isRefreshing, setIsRefreshing] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const startY = useRef(0)
+  const isPulling = useRef(false)
+
+  const THRESHOLD = 80 // 새로고침 트리거 거리
+
+  const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    const container = containerRef.current
+    if (!container || isRefreshing) return
+
+    // 스크롤이 맨 위에 있을 때만 pull-to-refresh 활성화
+    if (container.scrollTop === 0) {
+      startY.current = e.touches[0].clientY
+      isPulling.current = true
+    }
+  }, [isRefreshing])
+
+  const handleTouchMove = useCallback((e: React.TouchEvent) => {
+    if (!isPulling.current || isRefreshing) return
+
+    const currentY = e.touches[0].clientY
+    const diff = currentY - startY.current
+
+    if (diff > 0) {
+      // 저항감 있는 당김 효과 (로그 스케일)
+      const distance = Math.min(diff * 0.5, THRESHOLD * 1.5)
+      setPullDistance(distance)
+    }
+  }, [isRefreshing])
+
+  const handleTouchEnd = useCallback(async () => {
+    if (!isPulling.current) return
+    isPulling.current = false
+
+    if (pullDistance >= THRESHOLD && !isRefreshing) {
+      setIsRefreshing(true)
+      setPullDistance(THRESHOLD * 0.6) // 새로고침 중 인디케이터 위치
+
+      try {
+        await onRefresh()
+      } finally {
+        setIsRefreshing(false)
+        setPullDistance(0)
+      }
+    } else {
+      setPullDistance(0)
+    }
+  }, [pullDistance, isRefreshing, onRefresh])
+
+  const progress = Math.min(pullDistance / THRESHOLD, 1)
+
+  return (
+    <div
+      ref={containerRef}
+      className="h-full overflow-auto"
+      onTouchStart={handleTouchStart}
+      onTouchMove={handleTouchMove}
+      onTouchEnd={handleTouchEnd}
+    >
+      {/* Pull indicator */}
+      <div
+        className="flex justify-center items-center overflow-hidden transition-all duration-200"
+        style={{ height: pullDistance > 0 || isRefreshing ? `${Math.max(pullDistance, isRefreshing ? 48 : 0)}px` : 0 }}
+      >
+        <div
+          className="flex items-center justify-center"
+          style={{
+            opacity: progress,
+            transform: `rotate(${progress * 360}deg)`,
+          }}
+        >
+          <ArrowPathIcon
+            className={`w-6 h-6 text-primary/60 ${isRefreshing ? "animate-spin" : ""}`}
+          />
+        </div>
+      </div>
+
+      {children}
+    </div>
+  )
+}

--- a/components/question-card.tsx
+++ b/components/question-card.tsx
@@ -1,14 +1,18 @@
 "use client"
 
 import { useState, useRef, useEffect } from "react"
+import { ArrowPathIcon } from "@heroicons/react/24/outline"
 import type { Question } from "@/types/entities"
 
 interface QuestionCardProps {
   question: Question
   onVote: (option: number) => void
+  onRefresh?: () => void
+  onDetailClick?: () => void
   showResults?: boolean
   selectedOption?: number
   isLoading?: boolean
+  isRefreshing?: boolean
   showDate?: boolean
   hasVoted?: boolean
   hideVoteAfterMessage?: boolean
@@ -18,19 +22,23 @@ interface QuestionCardProps {
 export function QuestionCard({
   question,
   onVote,
+  onRefresh,
+  onDetailClick,
   showResults = false,
   selectedOption: controlledSelectedOption,
   isLoading = false,
+  isRefreshing = false,
   showDate = false,
   hasVoted = false,
   hideVoteAfterMessage = false,
   showDescription = false,
 }: QuestionCardProps) {
   const [localSelectedOption, setLocalSelectedOption] = useState<number | null>(null)
+  const [isSpinning, setIsSpinning] = useState(false)
   const cardRef = useRef<HTMLDivElement>(null)
 
-  // Use controlled prop if provided, otherwise use local state
-  const selectedOption = controlledSelectedOption !== undefined ? controlledSelectedOption : localSelectedOption
+  // localSelectedOption이 있으면 우선 사용 (사용자가 새 옵션 선택 중)
+  const selectedOption = localSelectedOption !== null ? localSelectedOption : controlledSelectedOption
 
   const handleOptionSelect = (option: number) => {
     // 선택만 하고 즉시 투표하지 않음
@@ -43,8 +51,14 @@ export function QuestionCard({
     // 제출 버튼 클릭 시 투표 실행
     if (localSelectedOption !== null && !isLoading && question.status !== "CLOSED") {
       onVote(localSelectedOption)
+      setLocalSelectedOption(null) // 제출 후 초기화
     }
   }
+
+  // controlledSelectedOption이 변경되면 localSelectedOption 초기화
+  useEffect(() => {
+    setLocalSelectedOption(null)
+  }, [controlledSelectedOption])
 
   // 외부 클릭 시 선택 초기화
   useEffect(() => {
@@ -65,41 +79,47 @@ export function QuestionCard({
 
   return (
     <div ref={cardRef} className="w-full bg-white rounded-lg border border-border p-4 md:p-6 space-y-3">
-      {/* 상단: 날짜 + 투표 후 확인 */}
+      {/* 상단: 날짜 + 상태 뱃지 + 상세보기 */}
       {showDate && (
         <div className="flex items-center justify-between text-sm md:text-base text-muted-foreground">
-          <div className="flex items-center gap-2.5">
+          <div className="flex items-center gap-2">
             <span className="font-medium">{question.date}</span>
-            <span>·</span>
-            <span>댓글 {question.commentCount}개</span>
+            {question.status === "CLOSED" ? (
+              <span className="px-2 py-0.5 rounded text-xs font-medium whitespace-nowrap bg-muted text-muted-foreground">
+                종료
+              </span>
+            ) : (
+              !hasVoted && !hideVoteAfterMessage && (
+                <span className="px-2 py-1 rounded-md text-xs font-semibold whitespace-nowrap bg-primary/10 text-primary">
+                  투표 후 확인
+                </span>
+              )
+            )}
           </div>
-          {!hasVoted && !hideVoteAfterMessage && (
-            <span className={`px-3 py-1.5 rounded-lg text-sm font-semibold whitespace-nowrap ${
-              question.status === "CLOSED"
-                ? "bg-muted text-muted-foreground"
-                : "bg-primary/10 text-primary"
-            }`}>
-              {question.status === "CLOSED" ? "투표 종료" : "투표 후 확인"}
-            </span>
+          {onDetailClick && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                onDetailClick()
+              }}
+              className="px-2.5 py-0.5 text-xs text-muted-foreground font-medium bg-muted rounded-full active:bg-muted/70 transition-colors"
+            >
+              질문상세
+            </button>
           )}
         </div>
       )}
 
-      <div className="flex items-start justify-between gap-2">
-        <h3 className="text-[15px] md:text-lg font-semibold text-foreground line-clamp-3">{question.title}</h3>
-        {question.isToday && (
-          <span className="text-xs font-semibold text-primary bg-primary/20 px-2 py-1 rounded-full whitespace-nowrap flex-shrink-0">
-            오늘의 질문
-          </span>
+      <div className="space-y-2">
+        <h3 className="text-lg md:text-xl font-bold text-foreground leading-snug">{question.title}</h3>
+
+        {/* Description */}
+        {question.description && showDescription && (
+          <p className="text-base md:text-[17px] text-foreground/80 leading-relaxed">
+            {question.description}
+          </p>
         )}
       </div>
-
-      {/* Description (상세 페이지용) */}
-      {question.description && showDescription && (
-        <p className="text-sm md:text-base text-muted-foreground leading-relaxed">
-          {question.description}
-        </p>
-      )}
 
       <div className="space-y-3">
         {question.options.map((option, i) => (
@@ -109,13 +129,13 @@ export function QuestionCard({
               e.stopPropagation()
               handleOptionSelect(i)
             }}
-            disabled={isLoading || !isVoteChangeable || showResults}
+            disabled={isLoading || !isVoteChangeable}
             className={`w-full p-4 md:p-5 rounded-lg border-2 transition-all font-medium text-sm md:text-base ${
               selectedOption === i
-                ? "border-primary bg-primary/15 text-primary"
-                : !isVoteChangeable || showResults
+                ? "border-primary/60 bg-primary/10 text-primary"
+                : !isVoteChangeable
                   ? "border-border bg-muted text-foreground cursor-not-allowed opacity-60"
-                  : "border-border active:border-primary/50 text-foreground active:bg-muted/50"
+                  : "border-border active:border-primary/60 text-foreground active:bg-primary/5"
             } ${isLoading ? "opacity-60 cursor-wait" : ""}`}
           >
             <div className="flex items-center justify-between">
@@ -130,27 +150,46 @@ export function QuestionCard({
         ))}
       </div>
 
-      {/* 투표 전: 제출 버튼 또는 투표 수 표시 */}
-      {!showResults && (
-        <div className="pt-1">
-          {selectedOption !== null ? (
-            <button
-              onClick={(e) => {
-                e.stopPropagation()
-                handleSubmit()
-              }}
-              disabled={isLoading}
-              className="w-full py-3 bg-primary/90 text-white rounded-lg font-semibold text-base transition-all active:scale-[0.98] hover:bg-primary disabled:opacity-60 disabled:cursor-wait"
-            >
-              {isLoading ? "제출 중..." : "제출"}
-            </button>
-          ) : (
-            <div className="text-sm md:text-base text-muted-foreground text-center py-2">
-              {question.totalVotes}명이 투표했습니다
-            </div>
-          )}
-        </div>
-      )}
+      {/* 제출 버튼 또는 투표 수 표시 */}
+      <div className="pt-1">
+        {localSelectedOption !== null && localSelectedOption !== controlledSelectedOption ? (
+          <button
+            onClick={(e) => {
+              e.stopPropagation()
+              handleSubmit()
+            }}
+            disabled={isLoading || !isVoteChangeable}
+            className="w-full py-3 bg-primary/60 text-white rounded-lg font-semibold text-base transition-all active:scale-[0.98] active:bg-primary/70 disabled:opacity-60 disabled:cursor-wait"
+          >
+            {isLoading ? "제출 중..." : hasVoted ? "투표 변경" : "제출"}
+          </button>
+        ) : (
+          <div className="flex items-center justify-center gap-3 py-2">
+            <span className="text-sm md:text-base text-muted-foreground">
+              {question.totalVotes.toLocaleString()}명 참여 · 댓글 {question.commentCount}개
+            </span>
+            {onRefresh && question.status !== "CLOSED" && (
+              <button
+                onClick={(e) => {
+                  e.stopPropagation()
+                  setIsSpinning(true)
+                  onRefresh()
+                  setTimeout(() => setIsSpinning(false), 500)
+                }}
+                disabled={isRefreshing || isSpinning}
+                className="p-1.5 text-muted-foreground active:text-primary transition-colors disabled:opacity-50"
+                aria-label="새로고침"
+              >
+                <ArrowPathIcon
+                  className={`w-4 h-4 transition-transform duration-500 ${
+                    isSpinning || isRefreshing ? "animate-spin" : ""
+                  }`}
+                />
+              </button>
+            )}
+          </div>
+        )}
+      </div>
     </div>
   )
 }

--- a/components/question-card.tsx
+++ b/components/question-card.tsx
@@ -77,8 +77,11 @@ export function QuestionCard({
   // 투표 변경 가능 여부: CLOSED가 아니면 변경 가능
   const isVoteChangeable = question.status !== "CLOSED"
 
+  // 참여하지 않은 종료된 질문은 블러 처리
+  const isClosedWithoutVote = question.status === "CLOSED" && !hasVoted
+
   return (
-    <div ref={cardRef} className="w-full bg-white rounded-lg border border-border p-4 md:p-6 space-y-3">
+    <div ref={cardRef} className="w-full bg-white rounded-lg border border-border p-4 md:p-6 space-y-3 relative overflow-hidden">
       {/* 상단: 날짜 + 상태 뱃지 + 상세보기 */}
       {showDate && (
         <div className="flex items-center justify-between text-sm md:text-base text-muted-foreground">
@@ -96,7 +99,7 @@ export function QuestionCard({
               )
             )}
           </div>
-          {onDetailClick && (
+          {onDetailClick && !isClosedWithoutVote && (
             <button
               onClick={(e) => {
                 e.stopPropagation()
@@ -121,33 +124,52 @@ export function QuestionCard({
         )}
       </div>
 
-      <div className="space-y-3">
-        {question.options.map((option, i) => (
+      <div className="relative">
+        {/* 옵션 버튼들 */}
+        <div className={`space-y-3 ${isClosedWithoutVote ? "blur-sm pointer-events-none" : ""}`}>
+          {question.options.map((option, i) => (
+            <button
+              key={i}
+              onClick={(e) => {
+                e.stopPropagation()
+                handleOptionSelect(i)
+              }}
+              disabled={isLoading || !isVoteChangeable}
+              className={`w-full p-4 md:p-5 rounded-lg border-2 transition-all font-medium text-sm md:text-base ${
+                selectedOption === i
+                  ? "border-primary/60 bg-primary/10 text-primary"
+                  : !isVoteChangeable
+                    ? "border-border bg-muted text-foreground cursor-not-allowed opacity-60"
+                    : "border-border active:border-primary/60 text-foreground active:bg-primary/5"
+              } ${isLoading ? "opacity-60 cursor-wait" : ""}`}
+            >
+              <div className="flex items-center justify-between">
+                <span className="truncate leading-relaxed">{option}</span>
+                {showResults && (
+                  <span className="text-sm md:text-base font-bold text-muted-foreground flex-shrink-0 ml-3">
+                    {question.votes[i].toFixed(1)}%
+                  </span>
+                )}
+              </div>
+            </button>
+          ))}
+        </div>
+
+        {/* 참여하지 않은 종료된 질문 오버레이 */}
+        {isClosedWithoutVote && (
           <button
-            key={i}
             onClick={(e) => {
               e.stopPropagation()
-              handleOptionSelect(i)
+              onDetailClick?.()
             }}
-            disabled={isLoading || !isVoteChangeable}
-            className={`w-full p-4 md:p-5 rounded-lg border-2 transition-all font-medium text-sm md:text-base ${
-              selectedOption === i
-                ? "border-primary/60 bg-primary/10 text-primary"
-                : !isVoteChangeable
-                  ? "border-border bg-muted text-foreground cursor-not-allowed opacity-60"
-                  : "border-border active:border-primary/60 text-foreground active:bg-primary/5"
-            } ${isLoading ? "opacity-60 cursor-wait" : ""}`}
+            className="absolute inset-0 flex items-center justify-center cursor-pointer"
           >
-            <div className="flex items-center justify-between">
-              <span className="truncate leading-relaxed">{option}</span>
-              {showResults && (
-                <span className="text-sm md:text-base font-bold text-muted-foreground flex-shrink-0 ml-3">
-                  {question.votes[i].toFixed(1)}%
-                </span>
-              )}
-            </div>
+            <p className="text-sm md:text-base text-muted-foreground text-center leading-relaxed">
+              종료된 질문입니다.<br />
+              투표에 참여하지 않아 결과를 볼 수 없습니다.
+            </p>
           </button>
-        ))}
+        )}
       </div>
 
       {/* 제출 버튼 또는 투표 수 표시 */}

--- a/components/ui/switch.tsx
+++ b/components/ui/switch.tsx
@@ -13,7 +13,7 @@ function Switch({
     <SwitchPrimitive.Root
       data-slot="switch"
       className={cn(
-        'peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
+        'peer data-[state=checked]:bg-primary/60 data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
         className,
       )}
       {...props}

--- a/hooks/use-comments.ts
+++ b/hooks/use-comments.ts
@@ -3,19 +3,41 @@
 import { useState, useCallback } from "react"
 import { Comment } from "@/types/entities"
 
+// 날짜 포맷 함수 (MM/DD HH:mm)
+function formatDate(date: Date): string {
+  const month = String(date.getMonth() + 1).padStart(2, "0")
+  const day = String(date.getDate()).padStart(2, "0")
+  const hours = String(date.getHours()).padStart(2, "0")
+  const minutes = String(date.getMinutes()).padStart(2, "0")
+  return `${month}/${day} ${hours}:${minutes}`
+}
+
+// 랜덤 닉네임 생성용 단어
+const adjectives = ["행복한", "빠른", "느긋한", "귀여운", "용감한", "졸린", "배고픈", "신나는", "차분한", "영리한"]
+const nouns = ["고양이", "강아지", "토끼", "다람쥐", "펭귄", "코알라", "판다", "여우", "사자", "호랑이"]
+
+function generateNickname(): string {
+  const adj = adjectives[Math.floor(Math.random() * adjectives.length)]
+  const noun = nouns[Math.floor(Math.random() * nouns.length)]
+  return `${adj}${noun}`
+}
+
+// 현재 사용자 닉네임 (실제로는 AuthContext에서 가져와야 함)
+const CURRENT_USER = "즐거운펭귄"
+
 // Mock data
 const mockCommentsData: Comment[] = [
   {
     id: "1",
-    author: "user01",
-    date: "25/10/04 20:15",
+    author: "행복한고양이",
+    date: "12/27 20:15",
     text: "AI 기술 발전은 필연적인 흐름이라고 생각해요. 중요한 건 이에 대한 준비입니다.",
     likes: 23,
     replies: [
       {
         id: "r1",
-        author: "user02",
-        date: "25/10/04 20:30",
+        author: "빠른토끼",
+        date: "12/27 20:30",
         text: "맞아요! 기술 변화에 대비하는 교육이 정말 중요하다고 봅니다.",
         likes: 5,
         replies: [],
@@ -23,8 +45,8 @@ const mockCommentsData: Comment[] = [
       },
       {
         id: "r2",
-        author: "user03",
-        date: "25/10/04 20:45",
+        author: "용감한사자",
+        date: "12/27 20:45",
         text: "하지만 일자리 감소로 인한 사회적 안전망도 필요하지 않을까요?",
         likes: 8,
         replies: [],
@@ -35,8 +57,8 @@ const mockCommentsData: Comment[] = [
   },
   {
     id: "2",
-    author: "techGuru_2024",
-    date: "25/10/04 19:45",
+    author: "귀여운판다",
+    date: "12/27 19:45",
     text: "AI가 단순 반복 업무를 대체하면 우리는 더 창의적인 일에 집중할 수 있습니다.",
     likes: 42,
     replies: [],
@@ -44,8 +66,8 @@ const mockCommentsData: Comment[] = [
   },
   {
     id: "3",
-    author: "economistMind",
-    date: "25/10/04 19:20",
+    author: "느긋한코알라",
+    date: "12/27 19:20",
     text: "역사적으로 기술 발전은 새로운 일자리를 만들어왔습니다. 산업 혁명 때도 그랬죠.",
     likes: 15,
     replies: [],
@@ -64,8 +86,8 @@ export function useComments(questionId: string) {
 
     const newComment: Comment = {
       id: `comment-${Date.now()}`,
-      author: "currentUser",
-      date: new Date().toLocaleString("ko-KR"),
+      author: CURRENT_USER,
+      date: formatDate(new Date()),
       text,
       likes: 0,
       replies: [],
@@ -81,8 +103,8 @@ export function useComments(questionId: string) {
 
     const reply: Comment = {
       id: `reply-${Date.now()}`,
-      author: "currentUser",
-      date: new Date().toLocaleString("ko-KR"),
+      author: CURRENT_USER,
+      date: formatDate(new Date()),
       text,
       likes: 0,
       replies: [],
@@ -132,6 +154,27 @@ export function useComments(questionId: string) {
     )
   }, [])
 
+  const deleteComment = useCallback((commentId: string) => {
+    setComments((prev) =>
+      prev
+        .filter((comment) => comment.id !== commentId)
+        .map((comment) => ({
+          ...comment,
+          replies: comment.replies.filter((reply) => reply.id !== commentId),
+        })),
+    )
+  }, [])
+
+  const blockUser = useCallback((commentId: string) => {
+    // TODO: API 연동 시 실제 차단 기능 구현
+    console.log("차단:", commentId)
+  }, [])
+
+  const reportComment = useCallback((commentId: string) => {
+    // TODO: API 연동 시 실제 신고 기능 구현
+    console.log("신고:", commentId)
+  }, [])
+
   return {
     comments,
     newCommentText,
@@ -143,5 +186,8 @@ export function useComments(questionId: string) {
     setReplyText,
     addReply,
     toggleLike,
+    deleteComment,
+    blockUser,
+    reportComment,
   }
 }

--- a/hooks/use-questions.ts
+++ b/hooks/use-questions.ts
@@ -16,7 +16,7 @@ export const ERROR_MESSAGES = {
 /**
  * 백엔드 응답을 프론트엔드 Question 타입으로 변환
  */
-function toQuestion(response: QuestionResponse, isToday = false): Question {
+export function toQuestion(response: QuestionResponse, isToday = false): Question {
   const voteStats = response.voteStats
   const votes = voteStats
     ? [voteStats.choice1Percent, voteStats.choice2Percent]
@@ -43,14 +43,23 @@ function toQuestion(response: QuestionResponse, isToday = false): Question {
 }
 
 /**
- * 날짜 포맷 변환 (ISO -> YY/MM/DD)
+ * 날짜 포맷 변환
+ * - 올해 → "M월 D일 (요일)"
+ * - 작년 이전 → "YYYY년 M월 D일 (요일)"
  */
 function formatDate(isoDate: string): string {
   const date = new Date(isoDate)
-  const yy = String(date.getFullYear()).slice(2)
-  const mm = String(date.getMonth() + 1).padStart(2, "0")
-  const dd = String(date.getDate()).padStart(2, "0")
-  return `${yy}/${mm}/${dd}`
+  const now = new Date()
+  const month = date.getMonth() + 1
+  const day = date.getDate()
+  const dayNames = ["일", "월", "화", "수", "목", "금", "토"]
+  const dayOfWeek = dayNames[date.getDay()]
+
+  if (date.getFullYear() === now.getFullYear()) {
+    return `${month}월 ${day}일 (${dayOfWeek})`
+  }
+
+  return `${date.getFullYear()}년 ${month}월 ${day}일 (${dayOfWeek})`
 }
 
 export function useQuestions() {
@@ -60,8 +69,9 @@ export function useQuestions() {
   const [isTodayLoading, setIsTodayLoading] = useState(false)
   const [isPastLoading, setIsPastLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [loadingId, setLoadingId] = useState<string | null>(null)
 
-  // useRef로 로딩 상태 추적 
+  // useRef로 로딩 상태 추적
   const isTodayLoadingRef = useRef(false)
   const isPastLoadingRef = useRef(false)
 
@@ -160,6 +170,72 @@ export function useQuestions() {
     [todayQuestion, pastQuestions]
   )
 
+  // 투표하기
+  const castVote = useCallback(
+    async (questionId: string, optionIndex: number) => {
+      // optionIndex는 0-based, API는 1-based
+      const choice = optionIndex + 1
+
+      setLoadingId(questionId)
+      try {
+        const response = await questionsApi.vote(Number(questionId), choice)
+        const { userChoice, participants, voteStats } = response.data
+
+        // 질문 상태 업데이트 헬퍼
+        const updateQuestion = (q: Question): Question => ({
+          ...q,
+          hasVoted: true,
+          userChoice: userChoice - 1, // API는 1-based, 프론트는 0-based
+          totalVotes: participants,
+          votes: [voteStats.choice1Percent, voteStats.choice2Percent],
+        })
+
+        // 오늘의 질문 업데이트
+        if (todayQuestion?.id === questionId) {
+          setTodayQuestion(updateQuestion(todayQuestion))
+        }
+
+        // 과거 질문 업데이트
+        setPastQuestions((prev) =>
+          prev.map((q) => (q.id === questionId ? updateQuestion(q) : q))
+        )
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "투표에 실패했습니다")
+      } finally {
+        setLoadingId(null)
+      }
+    },
+    [todayQuestion]
+  )
+
+  // 질문 새로고침 (참여 수, 댓글 수 업데이트)
+  const [refreshingId, setRefreshingId] = useState<string | null>(null)
+
+  const refreshQuestion = useCallback(
+    async (questionId: string) => {
+      setRefreshingId(questionId)
+      try {
+        const response = await questionsApi.getQuestionById(Number(questionId))
+        const updatedQuestion = toQuestion(response.data, todayQuestion?.id === questionId)
+
+        // 오늘의 질문 업데이트
+        if (todayQuestion?.id === questionId) {
+          setTodayQuestion(updatedQuestion)
+        }
+
+        // 과거 질문 업데이트
+        setPastQuestions((prev) =>
+          prev.map((q) => (q.id === questionId ? updatedQuestion : q))
+        )
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "새로고침에 실패했습니다")
+      } finally {
+        setRefreshingId(null)
+      }
+    },
+    [todayQuestion]
+  )
+
   // 통합 로딩 상태
   const isLoading = isTodayLoading || isPastLoading
 
@@ -174,6 +250,8 @@ export function useQuestions() {
     isPastLoading,
     error,
     hasMore: !!nextCursor,
+    loadingId,
+    refreshingId,
 
     // 액션
     fetchTodayQuestion,
@@ -182,9 +260,7 @@ export function useQuestions() {
     loadMore,
     hasUserVoted,
     getUserVote,
-
-    // TODO: 투표 API 연동 시 구현
-    loadingId: null,
-    castVote: (_questionId: string, _optionIndex: number) => {},
+    castVote,
+    refreshQuestion,
   }
 }

--- a/hooks/use-user-profile.ts
+++ b/hooks/use-user-profile.ts
@@ -1,92 +1,100 @@
 "use client"
 
-import { useState, useCallback, useEffect } from "react"
+import { useState, useCallback, useEffect, useRef } from "react"
 import { UserProfile, ActivityItem } from "@/types/user"
 import { useAuthContext } from "@/contexts/auth-context"
+import * as usersApi from "@/lib/api/users"
 
-// Mock activity data (실제 API 연동 시 제거)
-const mockActivityData = {
-  totalVotes: 47,
-  totalComments: 123,
-  engagementRate: 89,
-  joinDate: "2024-08-15",
-  recentActivity: [
-    { date: "10/01", count: 3 },
-    { date: "10/02", count: 2 },
-    { date: "10/03", count: 5 },
-    { date: "10/04", count: 4 },
-    { date: "10/05", count: 2 },
-    { date: "10/06", count: 4 },
-    { date: "10/07", count: 3 },
-  ],
-  bestComments: [
-    {
-      id: "c1",
-      text: "AI가 단순 반복 업무를 대체하면 우리는 더 창의적인 일에 집중할 수 있습니다.",
-      likes: 89,
-      questionId: "1",
-      date: "25/10/04",
-    },
-    {
-      id: "c2",
-      text: "기술 변화에 대비하는 교육이 정말 중요하다고 봅니다.",
-      likes: 52,
-      questionId: "1",
-      date: "25/10/03",
-    },
-  ],
+// weeklyActivity 배열을 ActivityItem 배열로 변환
+// API 순서: [오늘, 어제, 그제, ..., 6일전] → 그대로 사용 (1일차=오늘)
+function convertWeeklyActivity(weeklyActivity: boolean[]): ActivityItem[] {
+  // weeklyActivity가 7개 미만이면 뒤에 false로 채움 (오래된 날짜)
+  const paddedActivity = [...weeklyActivity, ...Array(7 - weeklyActivity.length).fill(false)]
+
+  return paddedActivity.map((participated, i) => ({
+    date: `${i + 1}일차`,
+    participated,
+    isToday: i === 0,
+  }))
+}
+
+// 기본 활동 데이터 생성 (API 실패 시 사용)
+function generateDefaultActivity(): ActivityItem[] {
+  return Array.from({ length: 7 }, (_, i) => ({
+    date: `${i + 1}일차`,
+    participated: false,
+    isToday: i === 0,
+  }))
 }
 
 export function useUserProfile() {
   const { user } = useAuthContext()
   const [profile, setProfile] = useState<UserProfile>({
-    id: user?.id.toString() || "user-001",
-    username: user?.nickname || "게스트",
-    bio: "매일의 질문으로 세상을 알아가고 있습니다",
-    ...mockActivityData,
+    id: "",
+    username: "로딩 중...",
+    totalVotes: 0,
+    totalComments: 0,
+    engagementRate: 0,
+    majorityRate: 0,
+    currentStreak: 0,
+    recentActivity: generateDefaultActivity(),
+    bestComments: [],
   })
-  const [editMode, setEditMode] = useState(false)
-  const [editedBio, setEditedBio] = useState(profile.bio || "")
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
 
-  // 로그인한 사용자 정보로 프로필 업데이트
-  useEffect(() => {
-    if (user) {
-      setProfile((prev) => ({
-        ...prev,
-        id: user.id.toString(),
-        username: user.nickname,
-      }))
+  // 중복 호출 방지
+  const isFetchingRef = useRef(false)
+
+  // 내 정보 조회
+  const fetchProfile = useCallback(async () => {
+    if (isFetchingRef.current) return
+    isFetchingRef.current = true
+
+    try {
+      setIsLoading(true)
+      setError(null)
+      const response = await usersApi.getMe()
+      const data = response.data
+
+      setProfile({
+        id: data.id.toString(),
+        username: data.nickname,
+        totalVotes: data.stats.totalVotes,
+        totalComments: data.stats.totalComments,
+        engagementRate: Math.round(data.stats.participationRate),
+        majorityRate: Math.round(data.stats.majorityRate),
+        currentStreak: data.stats.currentStreak,
+        recentActivity: convertWeeklyActivity(data.stats.weeklyActivity),
+        bestComments: [],
+      })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "프로필을 불러오지 못했습니다")
+      // 에러 시 auth context의 기본 정보 사용
+      if (user) {
+        setProfile((prev) => ({
+          ...prev,
+          id: user.id.toString(),
+          username: user.nickname,
+        }))
+      }
+    } finally {
+      setIsLoading(false)
+      isFetchingRef.current = false
     }
   }, [user])
 
-  const updateBio = useCallback((newBio: string) => {
-    setProfile((prev) => ({
-      ...prev,
-      bio: newBio,
-    }))
-    setEditMode(false)
-  }, [])
-
-  const getDaysSinceJoin = useCallback(() => {
-    const joinDate = new Date(profile.joinDate)
-    const today = new Date()
-    const diff = today.getTime() - joinDate.getTime()
-    return Math.floor(diff / (1000 * 60 * 60 * 24))
-  }, [profile.joinDate])
-
-  const getAverageDaily = useCallback(() => {
-    const days = getDaysSinceJoin()
-    return (profile.totalVotes / days).toFixed(1)
-  }, [profile.totalVotes, getDaysSinceJoin])
+  // 인증된 사용자일 때 프로필 로드
+  useEffect(() => {
+    if (user) {
+      fetchProfile()
+    }
+  }, [user, fetchProfile])
 
   return {
     profile,
-    editMode,
-    setEditMode,
-    editedBio,
-    setEditedBio,
-    updateBio,
-    getDaysSinceJoin,
-    getAverageDaily,
+    isLoading,
+    error,
+    fetchProfile,
   }
 }

--- a/lib/api/questions.ts
+++ b/lib/api/questions.ts
@@ -1,11 +1,13 @@
 // Question API 서비스 함수
 
-import { apiGet } from "@/lib/api-client"
+import { apiGet, apiPut } from "@/lib/api-client"
 import type {
   TodayQuestionResponse,
   PastQuestionsResponse,
   QuestionDetailResponse,
   QuestionResultResponse,
+  VoteResponse,
+  TopQuestionsResponse,
 } from "@/types/api"
 
 const BASE_PATH = "/api/v1/questions"
@@ -46,4 +48,20 @@ export async function getQuestionById(id: number) {
  */
 export async function getQuestionResults(id: number) {
   return apiGet<QuestionResultResponse>(`${BASE_PATH}/${id}/results`)
+}
+
+/**
+ * 투표하기 (이미 투표한 경우 선택지 변경)
+ * @param id 질문 ID
+ * @param choice 선택지 (1 또는 2)
+ */
+export async function vote(id: number, choice: number) {
+  return apiPut<VoteResponse>(`${BASE_PATH}/${id}/votes`, { choice })
+}
+
+/**
+ * 참여율 Top 5 질문 조회
+ */
+export async function getTopQuestions() {
+  return apiGet<TopQuestionsResponse>(`${BASE_PATH}/top`)
 }

--- a/lib/api/users.ts
+++ b/lib/api/users.ts
@@ -1,0 +1,13 @@
+// User API 서비스 함수
+
+import { apiGet } from "@/lib/api-client"
+import type { UserResponse } from "@/types/api"
+
+const BASE_PATH = "/api/v1/users"
+
+/**
+ * 내 정보 조회
+ */
+export async function getMe() {
+  return apiGet<UserResponse>(`${BASE_PATH}/me`)
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -756,17 +756,6 @@
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
     },
-<<<<<<< HEAD
-    "node_modules/@heroicons/react": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz",
-      "integrity": "sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": ">= 16 || ^19.0.0-rc"}
-    },
-=======
->>>>>>> ec043bb9a080dc104a5c9fbf2af6bea7a386448b
     "node_modules/@grpc/grpc-js": {
       "version": "1.9.15",
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.15.tgz",
@@ -796,6 +785,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@heroicons/react": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz",
+      "integrity": "sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">= 16 || ^19.0.0-rc"
       }
     },
     "node_modules/@hookform/resolvers": {
@@ -3184,7 +3182,6 @@
       "version": "22.19.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.1.tgz",
       "integrity": "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"

--- a/types/api.ts
+++ b/types/api.ts
@@ -88,3 +88,50 @@ export interface QuestionResultResponse {
   voteStats: VoteStats | null
   updatedAt: string
 }
+
+/**
+ * 투표 응답
+ */
+export interface VoteResponse {
+  questionId: number
+  userChoice: number
+  isChanged: boolean
+  participants: number
+  voteStats: VoteStats
+}
+
+/**
+ * 참여율 Top 5 질문 조회 응답
+ */
+export type TopQuestionsResponse = QuestionResponse[]
+
+/**
+ * 사용자 역할
+ */
+export type UserRole = "USER" | "ADMIN"
+
+/**
+ * 사용자 통계
+ */
+export interface UserStats {
+  totalVotes: number
+  totalComments: number
+  participationRate: number
+  majorityRate: number
+  currentStreak: number
+  weeklyActivity: boolean[]
+}
+
+/**
+ * 내 정보 조회 응답
+ */
+export interface UserResponse {
+  id: number
+  nickname: string
+  email: string
+  providerId: string
+  role: UserRole
+  isDeleted: boolean
+  notificationEnabled: boolean
+  stats: UserStats
+}

--- a/types/user.ts
+++ b/types/user.ts
@@ -12,7 +12,8 @@ export interface UserProfile {
   totalVotes: number
   totalComments: number
   engagementRate: number
-  joinDate: string
+  majorityRate: number
+  currentStreak: number
   recentActivity: ActivityItem[]
   bestComments: Comment[]
 }
@@ -22,5 +23,6 @@ export interface UserProfile {
  */
 export interface ActivityItem {
   date: string
-  count: number
+  participated: boolean
+  isToday?: boolean
 }


### PR DESCRIPTION
## 🔗 Issue Link
<!-- 관련 이슈 번호를 적어주세요. 해당 PR merge와 함께 이슈를 닫으려면 `close #이슈번호`를 적어주세요. -->
- #21 

## 🎯 What I Did
<!-- 이번 PR에서 구현하거나 수정한 주요 내용을 간결히 기술하세요. -->
홈 화면
- 오늘의 질문 중앙 배치 및 참여 유도 문구 추가
- Top 5 질문 섹션 추가 (API 연동)
- 질문 없는 경우 빈 상태 UI 개선

투표 API 연동
- 투표 후 실시간 결과 반영
- toQuestion() 헬퍼 함수로 API 응답 변환

질문 페이지
- 타이틀 제거 및 빈 상태 UI 개선

질문 상세 / 설정 페이지
- 타이틀 제거 및 뒤로가기 버튼 간격 조정

마이페이지
- Instagram 스타일 중앙 정렬 레이아웃
- 투표 성향 시스템 구현 (대세파/균형파/소신파)
- majorityRate API 연동

설정 페이지
- 회원탈퇴 확인 모달 추가
- Switch 토글 및 버튼 색상 통일

댓글 시스템
- 에브리타임 스타일 댓글 UI 개선
- 프로필 아이콘 3종 랜덤 배정
- 더보기 메뉴 (차단/신고/삭제) 추가
- 댓글 입력창 하단 고정

질문 상세 페이지
- VS 스타일 투표 UI로 변경
- 비율에 따른 배경 색상 채우기

설정 페이지
- 카드 스타일에서 구분선 스타일로 변경

열람권 시스템
- 미참여 종료 질문 블러 처리
- 열람권 사용 확인 모달 추가
- 7일 연속 참여 보상 UI 추가


## 🔍 Review Points
<!-- 리뷰어가 집중해서 봐야 할 부분이나 검증이 필요한 로직을 적어주세요. -->
- 투표 성향 분류 기준 (대세파 71%+, 균형파 31-70%, 소신파 0-30%)
- 회원탈퇴 모달 UX 및 문구
- Top 5 API 연동 방식
- 댓글 더보기 메뉴 UX
- 열람권 사용 모달 플로우

<!-- ## 🚀 Notes
실행, 환경 설정, 테스트에 필요한 추가 정보가 있다면 적어주세요. -->
