### PR TITLE
[Feature] 댓글/열람권 API 연동 및 UI/UX 개선

### DIFF
--- a/app/(main)/home/page.tsx
+++ b/app/(main)/home/page.tsx
@@ -7,15 +7,18 @@ import { LoadingSkeleton } from "@/components/loading-skeleton"
 import { PullToRefresh } from "@/components/pull-to-refresh"
 import { useQuestionsContext } from "@/contexts/questions-context"
 import { useAuthContext } from "@/contexts/auth-context"
+import { useUserProfile } from "@/hooks/use-user-profile"
 import { ERROR_MESSAGES, toQuestion } from "@/hooks/use-questions"
-import { BellIcon, ChartBarIcon } from "@heroicons/react/24/outline"
+import { BellIcon, ChartBarIcon, TicketIcon } from "@heroicons/react/24/outline"
 import Link from "next/link"
 import * as questionsApi from "@/lib/api/questions"
+import * as ticketsApi from "@/lib/api/tickets"
 import type { Question } from "@/types/entities"
 
 export default function HomePage() {
   const router = useRouter()
   const { isLoading: authLoading } = useAuthContext()
+  const { profile, fetchProfile } = useUserProfile()
   const {
     todayQuestion,
     fetchTodayQuestion,
@@ -31,6 +34,10 @@ export default function HomePage() {
 
   const [topQuestions, setTopQuestions] = useState<Question[]>([])
   const [isLoadingTop, setIsLoadingTop] = useState(true)
+  const [showTicketModal, setShowTicketModal] = useState(false)
+  const [selectedClosedQuestion, setSelectedClosedQuestion] = useState<Question | null>(null)
+  const [isUsingTicket, setIsUsingTicket] = useState(false)
+  const ticketCount = profile.ticketCount
 
   // 인증 완료 후 오늘의 질문 & Top 5 로드
   useEffect(() => {
@@ -55,6 +62,35 @@ export default function HomePage() {
     await fetchTodayQuestion()
   }, [fetchTodayQuestion])
 
+  const handleTopQuestionClick = (q: Question) => {
+    const canView = q.canViewResults ?? hasUserVoted(q.id)
+    const isClosedWithoutAccess = q.status === "CLOSED" && !canView
+
+    if (isClosedWithoutAccess) {
+      setSelectedClosedQuestion(q)
+      setShowTicketModal(true)
+    } else {
+      router.push(`/questions/${q.id}`)
+    }
+  }
+
+  const handleUseTicket = async () => {
+    if (!selectedClosedQuestion || ticketCount === 0) return
+
+    try {
+      setIsUsingTicket(true)
+      await ticketsApi.useTicket(Number(selectedClosedQuestion.id))
+      fetchProfile()
+      router.push(`/questions/${selectedClosedQuestion.id}`)
+    } catch (error) {
+      console.error("열람권 사용 실패:", error)
+    } finally {
+      setIsUsingTicket(false)
+      setShowTicketModal(false)
+      setSelectedClosedQuestion(null)
+    }
+  }
+
   const question = todayQuestion
 
   if (isLoading && !question) {
@@ -68,42 +104,133 @@ export default function HomePage() {
 
     return (
       <div className="w-full max-w-2xl mx-auto px-5 pt-6 pb-12 md:px-8 md:pt-10 md:pb-20">
-        <h1 className="text-2xl font-bold text-foreground mb-6">오늘의 질문</h1>
+        {/* Header - 질문 탭과 동일하게 상단 중앙 */}
+        <h1 className="text-2xl text-foreground text-center mb-5">오늘의 질문</h1>
 
-        <div className="flex flex-col items-center pt-16">
+        {/* 상태 메시지 카드 - Top 5 위치 맞추기 위해 높이 설정 */}
+        <div className="rounded-lg bg-white border border-border min-h-[55vh] flex flex-col items-center justify-center py-12 px-6 md:py-16 md:px-8 text-center">
           {isError ? (
             <>
-              <p className="text-4xl font-bold text-muted-foreground/40 mb-3">
+              <p className="text-4xl font-bold text-muted-foreground/30 mb-3">
                 앗!
               </p>
-              <p className="text-[15px] text-muted-foreground mb-6">
+              <p className="text-base font-medium text-foreground mb-1">
                 질문을 불러오지 못했어요
+              </p>
+              <p className="text-[13px] text-muted-foreground mb-6">
+                잠시 후 다시 시도해주세요
               </p>
               <button
                 onClick={() => fetchTodayQuestion()}
-                className="h-12 w-48 bg-primary/60 text-white rounded-xl font-semibold text-[15px] flex items-center justify-center active:scale-95 transition-transform"
+                className="h-11 px-8 bg-primary/40 text-white rounded-xl font-medium text-[15px] flex items-center justify-center active:scale-95 transition-transform"
               >
                 다시 시도
               </button>
             </>
           ) : (
             <>
-              <BellIcon className="w-16 h-16 text-primary/60 mb-4" />
-              <p className="text-[15px] text-muted-foreground mb-1">
+              <BellIcon className="w-12 h-12 text-primary/50 mb-4" />
+              <p className="text-base font-medium text-foreground mb-1">
                 아직 오늘의 질문이 없어요
               </p>
-              <p className="text-[13px] text-muted-foreground/70 mb-6">
+              <p className="text-[13px] text-muted-foreground mb-6">
                 알림을 켜두면 새 질문을 바로 받아볼 수 있어요
               </p>
               <Link
                 href="/settings"
-                className="h-12 w-48 bg-primary/60 text-white rounded-xl font-semibold text-[15px] flex items-center justify-center active:scale-95 transition-transform"
+                className="h-11 px-8 bg-primary/40 text-white rounded-xl font-medium text-[15px] flex items-center justify-center active:scale-95 transition-transform"
               >
                 알림 설정하기
               </Link>
             </>
           )}
         </div>
+
+        {/* Top 5 - 스크롤해서 볼 수 있는 영역 */}
+        {!isLoadingTop && topQuestions.length > 0 && (
+          <div className="mt-8 space-y-4">
+            <h2 className="text-lg font-semibold text-foreground flex items-center gap-2">
+              <ChartBarIcon className="w-5 h-5 text-primary" />
+              Top 5
+            </h2>
+            <div className="space-y-4">
+              {topQuestions.map((q) => (
+                <QuestionCard
+                  key={q.id}
+                  question={q}
+                  onVote={(optionIndex) => castVote(q.id, optionIndex)}
+                  onDetailClick={() => handleTopQuestionClick(q)}
+                  showResults={hasUserVoted(q.id)}
+                  selectedOption={getUserVote(q.id) ?? undefined}
+                  isLoading={loadingId === q.id}
+                  showDate={true}
+                  hasVoted={hasUserVoted(q.id)}
+                  showDescription={true}
+                />
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* 열람권 사용 확인 모달 */}
+        {showTicketModal && selectedClosedQuestion && (
+          <div className="fixed inset-0 z-50 flex items-center justify-center">
+            <div
+              className="absolute inset-0 bg-black/40"
+              onClick={() => {
+                setShowTicketModal(false)
+                setSelectedClosedQuestion(null)
+              }}
+            />
+            <div className="relative bg-card rounded-2xl border border-border p-6 mx-5 max-w-sm w-full shadow-xl">
+              <div className="flex flex-col items-center text-center">
+                <div className="w-14 h-14 bg-primary/10 rounded-full flex items-center justify-center mb-4">
+                  <TicketIcon className="w-7 h-7 text-primary" />
+                </div>
+                <h3 className="text-lg font-semibold text-foreground mb-2">
+                  열람권을 사용하시겠어요?
+                </h3>
+                <p className="text-sm text-muted-foreground mb-1">
+                  종료된 질문의 결과를 확인할 수 있어요
+                </p>
+                <p className="text-sm text-muted-foreground mb-6">
+                  보유 열람권: <span className="font-semibold text-primary">{ticketCount}개</span>
+                </p>
+                <div className="flex flex-col gap-2 w-full">
+                  <button
+                    onClick={handleUseTicket}
+                    disabled={ticketCount === 0 || isUsingTicket}
+                    className={`w-full py-3 px-4 rounded-xl font-medium text-[15px] active:scale-95 transition-transform ${
+                      ticketCount > 0 && !isUsingTicket
+                        ? "bg-primary/60 text-white"
+                        : "bg-muted text-muted-foreground cursor-not-allowed"
+                    }`}
+                  >
+                    {isUsingTicket ? (
+                      <span className="flex items-center justify-center gap-2">
+                        <span className="w-4 h-4 border-2 border-white/60 border-t-transparent rounded-full animate-spin" />
+                        사용 중...
+                      </span>
+                    ) : ticketCount > 0 ? (
+                      "열람권 사용하기"
+                    ) : (
+                      "열람권이 없어요"
+                    )}
+                  </button>
+                  <button
+                    onClick={() => {
+                      setShowTicketModal(false)
+                      setSelectedClosedQuestion(null)
+                    }}
+                    className="w-full py-3 px-4 bg-muted text-muted-foreground rounded-xl font-medium text-[15px] active:scale-95 transition-transform"
+                  >
+                    취소
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
       </div>
     )
   }
@@ -160,7 +287,7 @@ export default function HomePage() {
                 key={q.id}
                 question={q}
                 onVote={(optionIndex) => castVote(q.id, optionIndex)}
-                onDetailClick={() => router.push(`/questions/${q.id}`)}
+                onDetailClick={() => handleTopQuestionClick(q)}
                 showResults={hasUserVoted(q.id)}
                 selectedOption={getUserVote(q.id) ?? undefined}
                 isLoading={loadingId === q.id}
@@ -169,6 +296,66 @@ export default function HomePage() {
                 showDescription={true}
               />
             ))}
+          </div>
+        </div>
+      )}
+
+      {/* 열람권 사용 확인 모달 */}
+      {showTicketModal && selectedClosedQuestion && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
+          <div
+            className="absolute inset-0 bg-black/40"
+            onClick={() => {
+              setShowTicketModal(false)
+              setSelectedClosedQuestion(null)
+            }}
+          />
+          <div className="relative bg-card rounded-2xl border border-border p-6 mx-5 max-w-sm w-full shadow-xl">
+            <div className="flex flex-col items-center text-center">
+              <div className="w-14 h-14 bg-primary/10 rounded-full flex items-center justify-center mb-4">
+                <TicketIcon className="w-7 h-7 text-primary" />
+              </div>
+              <h3 className="text-lg font-semibold text-foreground mb-2">
+                열람권을 사용하시겠어요?
+              </h3>
+              <p className="text-sm text-muted-foreground mb-1">
+                종료된 질문의 결과를 확인할 수 있어요
+              </p>
+              <p className="text-sm text-muted-foreground mb-6">
+                보유 열람권: <span className="font-semibold text-primary">{ticketCount}개</span>
+              </p>
+              <div className="flex flex-col gap-2 w-full">
+                <button
+                  onClick={handleUseTicket}
+                  disabled={ticketCount === 0 || isUsingTicket}
+                  className={`w-full py-3 px-4 rounded-xl font-medium text-[15px] active:scale-95 transition-transform ${
+                    ticketCount > 0 && !isUsingTicket
+                      ? "bg-primary/60 text-white"
+                      : "bg-muted text-muted-foreground cursor-not-allowed"
+                  }`}
+                >
+                  {isUsingTicket ? (
+                    <span className="flex items-center justify-center gap-2">
+                      <span className="w-4 h-4 border-2 border-white/60 border-t-transparent rounded-full animate-spin" />
+                      사용 중...
+                    </span>
+                  ) : ticketCount > 0 ? (
+                    "열람권 사용하기"
+                  ) : (
+                    "열람권이 없어요"
+                  )}
+                </button>
+                <button
+                  onClick={() => {
+                    setShowTicketModal(false)
+                    setSelectedClosedQuestion(null)
+                  }}
+                  className="w-full py-3 px-4 bg-muted text-muted-foreground rounded-xl font-medium text-[15px] active:scale-95 transition-transform"
+                >
+                  취소
+                </button>
+              </div>
+            </div>
           </div>
         </div>
       )}

--- a/app/(main)/profile/page.tsx
+++ b/app/(main)/profile/page.tsx
@@ -122,7 +122,7 @@ export default function ProfilePage() {
             <h3 className="font-semibold text-foreground">7일 연속 참여 보상</h3>
             <div className="flex items-center gap-1.5 px-2.5 py-1 bg-primary/10 rounded-full">
               <TicketIcon className="w-4 h-4 text-primary" />
-              <span className="text-sm font-semibold text-primary">1개</span>
+              <span className="text-sm font-semibold text-primary">{profile.ticketCount}개</span>
             </div>
           </div>
 

--- a/app/(main)/questions/[id]/page.tsx
+++ b/app/(main)/questions/[id]/page.tsx
@@ -33,6 +33,7 @@ export default function QuestionDetailPage({ params }: { params: Promise<{ id: s
   // API로 불러온 question 객체에서 직접 사용
   const userVote = question?.userChoice ?? null
   const hasVoted = question?.hasVoted ?? false
+  const canViewResults = question?.canViewResults ?? hasVoted
 
   if (isLoading) {
     return <LoadingSkeleton />
@@ -64,8 +65,8 @@ export default function QuestionDetailPage({ params }: { params: Promise<{ id: s
     )
   }
 
-  // Handle CLOSED questions without user vote - show limited info
-  if (question.status === "CLOSED" && !hasVoted) {
+  // Handle CLOSED questions without access - show limited info
+  if (question.status === "CLOSED" && !canViewResults) {
     return (
       <div className="w-full max-w-2xl mx-auto px-5 pt-6 pb-12 md:px-8 md:pt-10 md:pb-20">
         {/* Back button */}
@@ -104,69 +105,67 @@ export default function QuestionDetailPage({ params }: { params: Promise<{ id: s
   }
 
   return (
-    <div className="w-full max-w-2xl mx-auto px-5 pt-6 pb-12 md:px-8 md:pt-10 md:pb-20">
-      {/* Header */}
-      <div className="relative flex items-center justify-center mb-6">
-        <button
-          onClick={() => router.back()}
-          className="absolute left-0 p-2.5 active:bg-muted rounded-lg transition-colors"
-        >
-          <ArrowLeftIcon className="w-6 h-6 text-foreground" />
-        </button>
-        <span className="text-lg font-medium text-muted-foreground">{question.date}</span>
-      </div>
+    <div className="flex flex-col h-[calc(100vh-64px)] md:h-[calc(100vh-80px)] max-w-2xl mx-auto">
+      {/* 고정 상단: 헤더 + 질문 */}
+      <div className="flex-shrink-0 px-5 pt-6 pb-4 md:px-8 md:pt-10 md:pb-6 bg-background border-b border-border">
+        {/* Header */}
+        <div className="relative flex items-center justify-center mb-4">
+          <button
+            onClick={() => router.back()}
+            className="absolute left-0 p-2.5 active:bg-muted rounded-lg transition-colors"
+          >
+            <ArrowLeftIcon className="w-6 h-6 text-foreground" />
+          </button>
+          <span className="text-lg font-medium text-muted-foreground">{question.date}</span>
+        </div>
 
-      <div className="space-y-8">
         {/* Title & Description */}
-        <div className="space-y-3">
-          <h1 className="text-2xl md:text-3xl font-bold text-foreground leading-tight">
+        <div className="space-y-2 mb-4">
+          <h1 className="text-xl md:text-2xl font-bold text-foreground leading-tight">
             {question.title}
           </h1>
           {question.description && (
-            <p className="text-base md:text-lg text-muted-foreground leading-relaxed">
+            <p className="text-sm md:text-base text-muted-foreground leading-relaxed">
               {question.description}
             </p>
           )}
         </div>
 
         {/* VS Vote Options */}
-        <div className="relative">
-          <div className="space-y-3">
-            {question.options.map((option, i) => {
-              const isSelected = userVote === i
+        <div className="space-y-2 mb-3">
+          {question.options.map((option, i) => {
+            const isSelected = userVote === i
 
-              return (
-                <button
-                  key={i}
-                  onClick={() => !hasVoted && question.status !== "CLOSED" && castVote(question.id, i)}
-                  disabled={loadingId === question.id || question.status === "CLOSED"}
-                  className={`w-full p-5 md:p-6 rounded-xl border-2 transition-all font-medium text-base md:text-lg relative overflow-hidden ${
-                    question.status === "CLOSED"
-                      ? "border-border bg-muted text-foreground cursor-not-allowed opacity-60"
-                      : hasVoted
-                        ? "border-primary/30 text-foreground"
-                        : "border-border text-foreground active:border-primary/60 active:bg-primary/5"
-                  } ${loadingId === question.id ? "opacity-60 cursor-wait" : ""}`}
-                >
-                  {/* 배경 채우기 - 비율만큼 */}
-                  {hasVoted && (
-                    <div className="absolute top-0 left-0 bottom-0 bg-primary/15 transition-all duration-500 rounded-l-lg"
-                      style={{ width: `${question.votes[i]}%` }}
-                    />
+            return (
+              <button
+                key={i}
+                onClick={() => question.status !== "CLOSED" && (!hasVoted || (question.canChangeVote ?? true)) && castVote(question.id, i)}
+                disabled={loadingId === question.id || question.status === "CLOSED"}
+                className={`w-full p-4 md:p-5 rounded-xl border-2 transition-all font-medium text-sm md:text-base relative overflow-hidden ${
+                  question.status === "CLOSED"
+                    ? "border-border bg-muted text-foreground cursor-not-allowed opacity-60"
+                    : canViewResults
+                      ? "border-primary/30 text-foreground"
+                      : "border-border text-foreground active:border-primary/60 active:bg-primary/5"
+                } ${loadingId === question.id ? "opacity-60 cursor-wait" : ""}`}
+              >
+                {/* 배경 채우기 - 비율만큼 */}
+                {canViewResults && (
+                  <div className="absolute top-0 left-0 bottom-0 bg-primary/15 transition-all duration-500 rounded-l-lg"
+                    style={{ width: `${question.votes[i]}%` }}
+                  />
+                )}
+                <div className="relative flex items-center justify-between">
+                  <span className="leading-relaxed">{option}</span>
+                  {canViewResults && (
+                    <span className="text-base font-bold text-foreground">
+                      {question.votes[i].toFixed(1)}%
+                    </span>
                   )}
-                  <div className="relative flex items-center justify-between">
-                    <span className="leading-relaxed">{option}</span>
-                    {hasVoted && (
-                      <span className="text-lg font-bold text-foreground">
-                        {question.votes[i].toFixed(1)}%
-                      </span>
-                    )}
-                  </div>
-                </button>
-              )
-            })}
-          </div>
-
+                </div>
+              </button>
+            )
+          })}
         </div>
 
         {/* Participation info */}
@@ -175,12 +174,14 @@ export default function QuestionDetailPage({ params }: { params: Promise<{ id: s
           <span>·</span>
           <span>댓글 {question.commentCount}개</span>
         </div>
-
-        {/* Show comments only if user has voted */}
-        {hasVoted && (
-          <CommentSection questionId={question.id} commentCount={question.commentCount} />
-        )}
       </div>
+
+      {/* 스크롤 가능한 댓글 영역 */}
+      {canViewResults && (
+        <div className="flex-1 overflow-y-auto">
+          <CommentSection questionId={question.id} commentCount={question.commentCount} />
+        </div>
+      )}
     </div>
   )
 }

--- a/app/(main)/questions/page.tsx
+++ b/app/(main)/questions/page.tsx
@@ -7,15 +7,19 @@ import { LoadingSkeleton } from "@/components/loading-skeleton"
 import { PullToRefresh } from "@/components/pull-to-refresh"
 import { useQuestionsContext } from "@/contexts/questions-context"
 import { useAuthContext } from "@/contexts/auth-context"
+import { useUserProfile } from "@/hooks/use-user-profile"
 import { ChatBubbleOvalLeftEllipsisIcon, TicketIcon } from "@heroicons/react/24/outline"
+import * as ticketsApi from "@/lib/api/tickets"
 import type { Question } from "@/types/entities"
 
 export default function QuestionsPage() {
   const router = useRouter()
   const { isLoading: authLoading } = useAuthContext()
+  const { profile, fetchProfile } = useUserProfile()
   const [showTicketModal, setShowTicketModal] = useState(false)
   const [selectedClosedQuestion, setSelectedClosedQuestion] = useState<Question | null>(null)
-  const ticketCount = 1 // TODO: 실제 열람권 개수 연동
+  const [isUsingTicket, setIsUsingTicket] = useState(false)
+  const ticketCount = profile.ticketCount
   const {
     todayQuestion,
     pastQuestions,
@@ -71,10 +75,10 @@ export default function QuestionsPage() {
     : pastQuestions
 
   const handleQuestionClick = (question: Question) => {
-    const hasVoted = hasUserVoted(question.id)
-    const isClosedWithoutVote = question.status === "CLOSED" && !hasVoted
+    const canView = question.canViewResults ?? hasUserVoted(question.id)
+    const isClosedWithoutAccess = question.status === "CLOSED" && !canView
 
-    if (isClosedWithoutVote) {
+    if (isClosedWithoutAccess) {
       setSelectedClosedQuestion(question)
       setShowTicketModal(true)
     } else {
@@ -82,13 +86,23 @@ export default function QuestionsPage() {
     }
   }
 
-  const handleUseTicket = () => {
-    if (selectedClosedQuestion && ticketCount > 0) {
-      // TODO: 열람권 사용 API 호출
+  const handleUseTicket = async () => {
+    if (!selectedClosedQuestion || ticketCount === 0) return
+
+    try {
+      setIsUsingTicket(true)
+      await ticketsApi.useTicket(Number(selectedClosedQuestion.id))
+      // 열람권 사용 후 프로필 갱신 (ticketCount 업데이트)
+      fetchProfile()
       router.push(`/questions/${selectedClosedQuestion.id}`)
+    } catch (error) {
+      console.error("열람권 사용 실패:", error)
+      // TODO: 에러 토스트 표시
+    } finally {
+      setIsUsingTicket(false)
+      setShowTicketModal(false)
+      setSelectedClosedQuestion(null)
     }
-    setShowTicketModal(false)
-    setSelectedClosedQuestion(null)
   }
 
   const handlePullRefresh = useCallback(async () => {
@@ -115,7 +129,7 @@ export default function QuestionsPage() {
               className={`rounded-lg bg-card transition-all duration-200
                 ${
                   question.isToday
-                    ? "border-2 border-primary/60"
+                    ? "border-2 border-primary/40"
                     : "border border-border"
                 }`}
             >
@@ -195,14 +209,23 @@ export default function QuestionsPage() {
               <div className="flex flex-col gap-2 w-full">
                 <button
                   onClick={handleUseTicket}
-                  disabled={ticketCount === 0}
+                  disabled={ticketCount === 0 || isUsingTicket}
                   className={`w-full py-3 px-4 rounded-xl font-medium text-[15px] active:scale-95 transition-transform ${
-                    ticketCount > 0
+                    ticketCount > 0 && !isUsingTicket
                       ? "bg-primary/60 text-white"
                       : "bg-muted text-muted-foreground cursor-not-allowed"
                   }`}
                 >
-                  {ticketCount > 0 ? "열람권 사용하기" : "열람권이 없어요"}
+                  {isUsingTicket ? (
+                    <span className="flex items-center justify-center gap-2">
+                      <span className="w-4 h-4 border-2 border-white/60 border-t-transparent rounded-full animate-spin" />
+                      사용 중...
+                    </span>
+                  ) : ticketCount > 0 ? (
+                    "열람권 사용하기"
+                  ) : (
+                    "열람권이 없어요"
+                  )}
                 </button>
                 <button
                   onClick={() => {

--- a/components/comment-item.tsx
+++ b/components/comment-item.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef, useEffect } from "react"
 import { UserGroupIcon, ScaleIcon, RocketLaunchIcon, HandThumbUpIcon, ChatBubbleOvalLeftIcon, EllipsisVerticalIcon } from "@heroicons/react/24/outline"
 import { HandThumbUpIcon as HandThumbUpSolidIcon } from "@heroicons/react/24/solid"
+import type { CommentDeletedBy } from "@/types/entities"
 
 interface CommentItemProps {
   id: string
@@ -13,6 +14,8 @@ interface CommentItemProps {
   isReply?: boolean
   userLiked?: boolean
   isOwn?: boolean
+  isDeleted?: boolean
+  deletedBy?: CommentDeletedBy
   onReply?: (commentId: string) => void
   onLike?: (commentId: string) => void
   onDelete?: (commentId: string) => void
@@ -29,6 +32,8 @@ export function CommentItem({
   isReply = false,
   userLiked = false,
   isOwn = false,
+  isDeleted = false,
+  deletedBy = null,
   onReply,
   onLike,
   onDelete,
@@ -43,6 +48,14 @@ export function CommentItem({
   const iconIndex = author.charCodeAt(0) % 3
   const ProfileIcon = profileIcons[iconIndex]
 
+  // 삭제된 댓글 메시지
+  const getDisplayText = () => {
+    if (!isDeleted) return text
+    return deletedBy === "ADMIN"
+      ? "관리자에 의해 삭제된 댓글입니다"
+      : "삭제된 댓글입니다"
+  }
+
   // 메뉴 외부 클릭 시 닫기
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
@@ -53,6 +66,26 @@ export function CommentItem({
     document.addEventListener("mousedown", handleClickOutside)
     return () => document.removeEventListener("mousedown", handleClickOutside)
   }, [])
+
+  // 삭제된 댓글은 액션 비활성화
+  if (isDeleted) {
+    return (
+      <div className={`${isReply ? "ml-6 pl-3 border-l-2 border-muted" : ""}`}>
+        <div className="flex items-center gap-1.5 mb-1">
+          <div className="w-5 h-5 rounded-full flex items-center justify-center bg-muted text-muted-foreground">
+            <ProfileIcon className="w-3 h-3" />
+          </div>
+          <span className="text-[15px] font-medium text-muted-foreground">{author}</span>
+        </div>
+        <p className="text-base text-muted-foreground italic leading-relaxed mb-1.5 pl-[26px]">
+          {getDisplayText()}
+        </p>
+        <div className="flex items-center gap-2 pl-[26px]">
+          <span className="text-sm text-muted-foreground">{date}</span>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div className={`${isReply ? "ml-6 pl-3 border-l-2 border-muted" : ""}`}>
@@ -102,7 +135,7 @@ export function CommentItem({
                       onDelete?.(id)
                       setShowMenu(false)
                     }}
-                    className="w-full px-3 py-2 text-left text-sm text-destructive hover:bg-muted"
+                    className="w-full px-3 py-2 text-left text-sm text-destructive active:bg-muted"
                   >
                     삭제
                   </button>
@@ -113,7 +146,7 @@ export function CommentItem({
                         onBlock?.(id)
                         setShowMenu(false)
                       }}
-                      className="w-full px-3 py-2 text-left text-sm text-foreground hover:bg-muted"
+                      className="w-full px-3 py-2 text-left text-sm text-foreground active:bg-muted"
                     >
                       차단
                     </button>
@@ -122,7 +155,7 @@ export function CommentItem({
                         onReport?.(id)
                         setShowMenu(false)
                       }}
-                      className="w-full px-3 py-2 text-left text-sm text-foreground hover:bg-muted"
+                      className="w-full px-3 py-2 text-left text-sm text-foreground active:bg-muted"
                     >
                       신고
                     </button>
@@ -135,7 +168,7 @@ export function CommentItem({
       </div>
 
       {/* 댓글 내용 */}
-      <p className="text-base text-foreground leading-relaxed mb-1.5 pl-[26px]">{text}</p>
+      <p className="text-base text-foreground leading-relaxed mb-1.5 pl-[26px]">{getDisplayText()}</p>
 
       {/* 날짜 & 좋아요 수 */}
       <div className="flex items-center gap-2 pl-[26px]">

--- a/components/comment-section.tsx
+++ b/components/comment-section.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { useRef, useEffect, useCallback } from "react"
 import { PaperAirplaneIcon } from "@heroicons/react/24/solid"
 import { CommentItem } from "@/components/comment-item"
 import { useComments } from "@/hooks/use-comments"
@@ -24,7 +25,37 @@ export function CommentSection({ questionId, commentCount }: CommentSectionProps
     deleteComment,
     blockUser,
     reportComment,
+    isLoading,
+    isSubmitting,
+    hasMore,
+    loadMore,
+    isOwnComment,
   } = useComments(questionId)
+
+  // 무한스크롤을 위한 observer
+  const observerTarget = useRef<HTMLDivElement>(null)
+
+  const handleObserver = useCallback(
+    (entries: IntersectionObserverEntry[]) => {
+      const [target] = entries
+      if (target.isIntersecting && hasMore && !isLoading) {
+        loadMore()
+      }
+    },
+    [hasMore, isLoading, loadMore]
+  )
+
+  useEffect(() => {
+    const element = observerTarget.current
+    if (!element) return
+
+    const observer = new IntersectionObserver(handleObserver, {
+      threshold: 0.1,
+    })
+
+    observer.observe(element)
+    return () => observer.unobserve(element)
+  }, [handleObserver])
 
   const handleSubmitComment = () => {
     if (newCommentText.trim()) {
@@ -39,11 +70,11 @@ export function CommentSection({ questionId, commentCount }: CommentSectionProps
   }
 
   return (
-    <>
-      <div className="space-y-4 pb-32">
-        {/* 댓글 목록 */}
+    <div className="flex flex-col h-full">
+      {/* 댓글 목록 - 스크롤 영역 */}
+      <div className="flex-1 overflow-y-auto px-5 md:px-8 py-4">
         <div className="space-y-0">
-          {comments.length === 0 ? (
+          {comments.length === 0 && !isLoading ? (
             <p className="text-sm text-muted-foreground text-center py-8">
               첫 번째 댓글을 남겨보세요
             </p>
@@ -61,8 +92,10 @@ export function CommentSection({ questionId, commentCount }: CommentSectionProps
                     text={comment.text}
                     likes={comment.likes}
                     userLiked={comment.userLiked}
-                    isOwn={comment.author === "즐거운펭귄"}
-                    onReply={() => setReplyingTo(replyingTo === comment.id ? null : comment.id)}
+                    isOwn={isOwnComment(comment.userId)}
+                    isDeleted={comment.isDeleted}
+                    deletedBy={comment.deletedBy}
+                    onReply={!comment.isDeleted ? () => setReplyingTo(replyingTo === comment.id ? null : comment.id) : undefined}
                     onLike={() => toggleLike(comment.id)}
                     onDelete={() => deleteComment(comment.id)}
                     onBlock={() => blockUser(comment.id)}
@@ -82,7 +115,9 @@ export function CommentSection({ questionId, commentCount }: CommentSectionProps
                           likes={reply.likes}
                           isReply={true}
                           userLiked={reply.userLiked}
-                          isOwn={reply.author === "즐거운펭귄"}
+                          isOwn={isOwnComment(reply.userId)}
+                          isDeleted={reply.isDeleted}
+                          deletedBy={reply.deletedBy}
                           onLike={() => toggleLike(reply.id)}
                           onDelete={() => deleteComment(reply.id)}
                           onBlock={() => blockUser(reply.id)}
@@ -92,8 +127,8 @@ export function CommentSection({ questionId, commentCount }: CommentSectionProps
                     </div>
                   )}
 
-                  {/* 답글 입력 */}
-                  {replyingTo === comment.id && (
+                  {/* 답글 입력 - 삭제된 댓글에는 답글 불가 */}
+                  {replyingTo === comment.id && !comment.isDeleted && (
                     <div className="mt-3 ml-6 pl-3 border-l-2 border-muted">
                       <div className="flex items-center gap-2">
                         <input
@@ -113,7 +148,7 @@ export function CommentSection({ questionId, commentCount }: CommentSectionProps
                         />
                         <button
                           onClick={() => handleSubmitReply(comment.id)}
-                          disabled={!replyText.trim()}
+                          disabled={!replyText.trim() || isSubmitting}
                           className="p-2 text-primary/60 disabled:opacity-40"
                         >
                           <PaperAirplaneIcon className="w-5 h-5" />
@@ -126,11 +161,23 @@ export function CommentSection({ questionId, commentCount }: CommentSectionProps
             ))
           )}
         </div>
+
+        {/* 무한스크롤 트리거 & 로딩 */}
+        {hasMore && (
+          <div ref={observerTarget} className="py-4 text-center">
+            {isLoading && (
+              <div className="inline-flex items-center gap-2 text-sm text-muted-foreground">
+                <div className="w-4 h-4 border-2 border-primary/60 border-t-transparent rounded-full animate-spin" />
+                <span>로딩 중...</span>
+              </div>
+            )}
+          </div>
+        )}
       </div>
 
-      {/* 댓글 입력 - 하단 고정 (네비게이션 위) */}
-      <div className="fixed bottom-16 md:bottom-20 left-0 right-0 bg-background border-t border-border px-5 py-3 z-40">
-        <div className="max-w-2xl mx-auto flex items-center gap-2">
+      {/* 댓글 입력 - 하단 고정 */}
+      <div className="flex-shrink-0 bg-background border-t border-border px-5 py-3">
+        <div className="flex items-center gap-2">
           <input
             type="text"
             value={newCommentText}
@@ -146,13 +193,13 @@ export function CommentSection({ questionId, commentCount }: CommentSectionProps
           />
           <button
             onClick={handleSubmitComment}
-            disabled={!newCommentText.trim()}
+            disabled={!newCommentText.trim() || isSubmitting}
             className="p-2 text-primary/60 disabled:opacity-40"
           >
             <PaperAirplaneIcon className="w-5 h-5" />
           </button>
         </div>
       </div>
-    </>
+    </div>
   )
 }

--- a/components/question-card.tsx
+++ b/components/question-card.tsx
@@ -74,11 +74,12 @@ export function QuestionCard({
     }
   }, [showResults])
 
-  // 투표 변경 가능 여부: CLOSED가 아니면 변경 가능
-  const isVoteChangeable = question.status !== "CLOSED"
+  // 투표 가능 여부: CLOSED가 아니고, 첫 투표이거나 투표 변경이 허용된 경우
+  const isVoteChangeable = question.status !== "CLOSED" && (!hasVoted || (question.canChangeVote ?? true))
 
-  // 참여하지 않은 종료된 질문은 블러 처리
-  const isClosedWithoutVote = question.status === "CLOSED" && !hasVoted
+  // 참여하지 않고 열람권도 사용 안 한 종료된 질문은 블러 처리
+  const canViewResults = question.canViewResults ?? hasVoted
+  const isClosedWithoutAccess = question.status === "CLOSED" && !canViewResults
 
   return (
     <div ref={cardRef} className="w-full bg-white rounded-lg border border-border p-4 md:p-6 space-y-3 relative overflow-hidden">
@@ -93,13 +94,13 @@ export function QuestionCard({
               </span>
             ) : (
               !hasVoted && !hideVoteAfterMessage && (
-                <span className="px-2 py-1 rounded-md text-xs font-semibold whitespace-nowrap bg-primary/10 text-primary">
+                <span className="px-2 py-1 rounded-md text-xs font-semibold whitespace-nowrap bg-primary/10 text-primary/60">
                   투표 후 확인
                 </span>
               )
             )}
           </div>
-          {onDetailClick && !isClosedWithoutVote && (
+          {onDetailClick && !isClosedWithoutAccess && (
             <button
               onClick={(e) => {
                 e.stopPropagation()
@@ -126,7 +127,7 @@ export function QuestionCard({
 
       <div className="relative">
         {/* 옵션 버튼들 */}
-        <div className={`space-y-3 ${isClosedWithoutVote ? "blur-sm pointer-events-none" : ""}`}>
+        <div className={`space-y-3 ${isClosedWithoutAccess ? "blur-sm pointer-events-none" : ""}`}>
           {question.options.map((option, i) => (
             <button
               key={i}
@@ -155,8 +156,8 @@ export function QuestionCard({
           ))}
         </div>
 
-        {/* 참여하지 않은 종료된 질문 오버레이 */}
-        {isClosedWithoutVote && (
+        {/* 참여하지 않고 열람권도 사용 안 한 종료된 질문 오버레이 */}
+        {isClosedWithoutAccess && (
           <button
             onClick={(e) => {
               e.stopPropagation()

--- a/hooks/use-comments.ts
+++ b/hooks/use-comments.ts
@@ -1,10 +1,15 @@
 "use client"
 
-import { useState, useCallback } from "react"
+import { useState, useCallback, useEffect, useRef } from "react"
 import { Comment } from "@/types/entities"
+import type { CommentResponse, CommentReplyResponse } from "@/types/api"
+import * as commentsApi from "@/lib/api/comments"
 
-// 날짜 포맷 함수 (MM/DD HH:mm)
-function formatDate(date: Date): string {
+/**
+ * 날짜 포맷 함수 (MM/DD HH:mm)
+ */
+function formatDate(isoDate: string): string {
+  const date = new Date(isoDate)
   const month = String(date.getMonth() + 1).padStart(2, "0")
   const day = String(date.getDate()).padStart(2, "0")
   const hours = String(date.getHours()).padStart(2, "0")
@@ -12,168 +17,335 @@ function formatDate(date: Date): string {
   return `${month}/${day} ${hours}:${minutes}`
 }
 
-// 랜덤 닉네임 생성용 단어
-const adjectives = ["행복한", "빠른", "느긋한", "귀여운", "용감한", "졸린", "배고픈", "신나는", "차분한", "영리한"]
-const nouns = ["고양이", "강아지", "토끼", "다람쥐", "펭귄", "코알라", "판다", "여우", "사자", "호랑이"]
-
-function generateNickname(): string {
-  const adj = adjectives[Math.floor(Math.random() * adjectives.length)]
-  const noun = nouns[Math.floor(Math.random() * nouns.length)]
-  return `${adj}${noun}`
+/**
+ * API 대댓글 응답을 Comment 엔티티로 변환
+ */
+function toReplyComment(reply: CommentReplyResponse, parentId: string): Comment {
+  return {
+    id: String(reply.commentId),
+    author: reply.userNickname,
+    userId: reply.userId,
+    date: formatDate(reply.createdAt),
+    text: reply.content,
+    likes: reply.likeCount,
+    userLiked: reply.isLiked,
+    replies: [],
+    isDeleted: reply.isDeleted,
+    deletedBy: reply.deletedBy,
+    parentId,
+  }
 }
 
-// 현재 사용자 닉네임 (실제로는 AuthContext에서 가져와야 함)
-const CURRENT_USER = "즐거운펭귄"
-
-// Mock data
-const mockCommentsData: Comment[] = [
-  {
-    id: "1",
-    author: "행복한고양이",
-    date: "12/27 20:15",
-    text: "AI 기술 발전은 필연적인 흐름이라고 생각해요. 중요한 건 이에 대한 준비입니다.",
-    likes: 23,
-    replies: [
-      {
-        id: "r1",
-        author: "빠른토끼",
-        date: "12/27 20:30",
-        text: "맞아요! 기술 변화에 대비하는 교육이 정말 중요하다고 봅니다.",
-        likes: 5,
-        replies: [],
-        userLiked: false,
-      },
-      {
-        id: "r2",
-        author: "용감한사자",
-        date: "12/27 20:45",
-        text: "하지만 일자리 감소로 인한 사회적 안전망도 필요하지 않을까요?",
-        likes: 8,
-        replies: [],
-        userLiked: false,
-      },
-    ],
-    userLiked: false,
-  },
-  {
-    id: "2",
-    author: "귀여운판다",
-    date: "12/27 19:45",
-    text: "AI가 단순 반복 업무를 대체하면 우리는 더 창의적인 일에 집중할 수 있습니다.",
-    likes: 42,
-    replies: [],
-    userLiked: false,
-  },
-  {
-    id: "3",
-    author: "느긋한코알라",
-    date: "12/27 19:20",
-    text: "역사적으로 기술 발전은 새로운 일자리를 만들어왔습니다. 산업 혁명 때도 그랬죠.",
-    likes: 15,
-    replies: [],
-    userLiked: true,
-  },
-]
+/**
+ * API 댓글 응답을 Comment 엔티티로 변환
+ */
+function toComment(response: CommentResponse): Comment {
+  return {
+    id: String(response.commentId),
+    author: response.userNickname,
+    userId: response.userId,
+    date: formatDate(response.createdAt),
+    text: response.content,
+    likes: response.likeCount,
+    userLiked: response.isLiked,
+    replies: response.replies.map((r) => toReplyComment(r, String(response.commentId))),
+    isDeleted: response.isDeleted,
+    deletedBy: response.deletedBy,
+    parentId: response.parentId ? String(response.parentId) : null,
+  }
+}
 
 export function useComments(questionId: string) {
-  const [comments, setComments] = useState<Comment[]>(mockCommentsData)
+  const [comments, setComments] = useState<Comment[]>([])
   const [newCommentText, setNewCommentText] = useState("")
   const [replyingTo, setReplyingTo] = useState<string | null>(null)
   const [replyText, setReplyText] = useState("")
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [page, setPage] = useState(1)
+  const [hasMore, setHasMore] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
 
-  const addComment = useCallback((text: string) => {
-    if (!text.trim()) return
+  // 현재 사용자 ID (AuthContext에서 가져와야 하지만 일단 localStorage에서)
+  const [currentUserId, setCurrentUserId] = useState<number | null>(null)
 
-    const newComment: Comment = {
-      id: `comment-${Date.now()}`,
-      author: CURRENT_USER,
-      date: formatDate(new Date()),
-      text,
-      likes: 0,
-      replies: [],
-      userLiked: false,
+  // 중복 호출 방지
+  const isLoadingRef = useRef(false)
+  const isSubmittingRef = useRef(false)
+
+  // 현재 사용자 ID 로드
+  useEffect(() => {
+    // TODO: AuthContext에서 실제 userId 가져오기
+    const storedUserId = localStorage.getItem("user_id")
+    if (storedUserId) {
+      setCurrentUserId(Number(storedUserId))
     }
-
-    setComments((prev) => [newComment, ...prev])
-    setNewCommentText("")
   }, [])
 
-  const addReply = useCallback((parentId: string, text: string) => {
-    if (!text.trim()) return
+  // 댓글 목록 조회
+  const fetchComments = useCallback(async (pageNum = 1, append = false) => {
+    if (isLoadingRef.current) return
+    isLoadingRef.current = true
 
-    const reply: Comment = {
-      id: `reply-${Date.now()}`,
-      author: CURRENT_USER,
-      date: formatDate(new Date()),
-      text,
-      likes: 0,
-      replies: [],
-      userLiked: false,
+    try {
+      setIsLoading(true)
+      setError(null)
+      const response = await commentsApi.getComments(Number(questionId), {
+        page: pageNum,
+        size: 10,
+      })
+
+      const newComments = response.data.items.map(toComment)
+
+      if (append) {
+        setComments((prev) => [...prev, ...newComments])
+      } else {
+        setComments(newComments)
+      }
+
+      setPage(pageNum)
+      setHasMore(response.data.hasNext)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "댓글을 불러오지 못했습니다")
+    } finally {
+      setIsLoading(false)
+      isLoadingRef.current = false
     }
+  }, [questionId])
 
-    setComments((prev) =>
-      prev.map((comment) => {
-        if (comment.id === parentId) {
-          return {
-            ...comment,
-            replies: [reply, ...comment.replies],
-          }
-        }
-        return comment
-      }),
-    )
-    setReplyingTo(null)
-    setReplyText("")
-  }, [])
+  // 초기 로드
+  useEffect(() => {
+    fetchComments(1)
+  }, [fetchComments])
 
-  const toggleLike = useCallback((commentId: string) => {
-    setComments((prev) =>
-      prev.map((comment) => {
-        if (comment.id === commentId) {
-          return {
-            ...comment,
-            likes: comment.userLiked ? comment.likes - 1 : comment.likes + 1,
-            userLiked: !comment.userLiked,
-          }
-        }
-        // Also update nested replies
-        return {
-          ...comment,
-          replies: comment.replies.map((reply) => {
-            if (reply.id === commentId) {
-              return {
-                ...reply,
-                likes: reply.userLiked ? reply.likes - 1 : reply.likes + 1,
-                userLiked: !reply.userLiked,
-              }
+  // 더 불러오기
+  const loadMore = useCallback(() => {
+    if (hasMore && !isLoadingRef.current) {
+      fetchComments(page + 1, true)
+    }
+  }, [hasMore, page, fetchComments])
+
+  // 댓글 작성
+  const addComment = useCallback(async (text: string) => {
+    if (!text.trim() || isSubmittingRef.current) return
+
+    isSubmittingRef.current = true
+    setIsSubmitting(true)
+
+    try {
+      const response = await commentsApi.createComment({
+        questionId: Number(questionId),
+        parentId: null,
+        content: text,
+      })
+
+      const newComment = toComment(response.data)
+      setComments((prev) => [newComment, ...prev])
+      setNewCommentText("")
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "댓글 작성에 실패했습니다")
+    } finally {
+      isSubmittingRef.current = false
+      setIsSubmitting(false)
+    }
+  }, [questionId])
+
+  // 대댓글 작성
+  const addReply = useCallback(async (parentId: string, text: string) => {
+    if (!text.trim() || isSubmittingRef.current) return
+
+    isSubmittingRef.current = true
+    setIsSubmitting(true)
+
+    try {
+      const response = await commentsApi.createComment({
+        questionId: Number(questionId),
+        parentId: Number(parentId),
+        content: text,
+      })
+
+      const newReply = toComment(response.data)
+      // replies 배열이 빈 배열로 오므로, toReplyComment 형태로 변환
+      const replyComment: Comment = {
+        ...newReply,
+        parentId,
+      }
+
+      setComments((prev) =>
+        prev.map((comment) => {
+          if (comment.id === parentId) {
+            return {
+              ...comment,
+              replies: [...comment.replies, replyComment],
             }
-            return reply
-          }),
-        }
-      }),
-    )
+          }
+          return comment
+        })
+      )
+      setReplyingTo(null)
+      setReplyText("")
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "답글 작성에 실패했습니다")
+    } finally {
+      isSubmittingRef.current = false
+      setIsSubmitting(false)
+    }
+  }, [questionId])
+
+  // 좋아요 토글
+  const toggleLike = useCallback(async (commentId: string) => {
+    // 먼저 현재 상태 확인
+    let targetComment: Comment | undefined
+    let isReply = false
+    let parentCommentId: string | undefined
+
+    // 댓글에서 찾기
+    for (const comment of comments) {
+      if (comment.id === commentId) {
+        targetComment = comment
+        break
+      }
+      // 대댓글에서 찾기
+      const reply = comment.replies.find((r) => r.id === commentId)
+      if (reply) {
+        targetComment = reply
+        isReply = true
+        parentCommentId = comment.id
+        break
+      }
+    }
+
+    if (!targetComment) return
+
+    const isCurrentlyLiked = targetComment.userLiked
+
+    try {
+      // 낙관적 업데이트
+      setComments((prev) =>
+        prev.map((comment) => {
+          if (comment.id === commentId) {
+            return {
+              ...comment,
+              likes: isCurrentlyLiked ? comment.likes - 1 : comment.likes + 1,
+              userLiked: !isCurrentlyLiked,
+            }
+          }
+          // 대댓글 업데이트
+          return {
+            ...comment,
+            replies: comment.replies.map((reply) => {
+              if (reply.id === commentId) {
+                return {
+                  ...reply,
+                  likes: isCurrentlyLiked ? reply.likes - 1 : reply.likes + 1,
+                  userLiked: !isCurrentlyLiked,
+                }
+              }
+              return reply
+            }),
+          }
+        })
+      )
+
+      // API 호출
+      if (isCurrentlyLiked) {
+        await commentsApi.unlikeComment(Number(commentId))
+      } else {
+        await commentsApi.likeComment(Number(commentId))
+      }
+    } catch (err) {
+      // 롤백
+      setComments((prev) =>
+        prev.map((comment) => {
+          if (comment.id === commentId) {
+            return {
+              ...comment,
+              likes: isCurrentlyLiked ? comment.likes + 1 : comment.likes - 1,
+              userLiked: isCurrentlyLiked,
+            }
+          }
+          return {
+            ...comment,
+            replies: comment.replies.map((reply) => {
+              if (reply.id === commentId) {
+                return {
+                  ...reply,
+                  likes: isCurrentlyLiked ? reply.likes + 1 : reply.likes - 1,
+                  userLiked: isCurrentlyLiked,
+                }
+              }
+              return reply
+            }),
+          }
+        })
+      )
+      setError(err instanceof Error ? err.message : "좋아요에 실패했습니다")
+    }
+  }, [comments])
+
+  // 댓글 삭제
+  const deleteComment = useCallback(async (commentId: string) => {
+    try {
+      await commentsApi.deleteComment(Number(commentId))
+
+      // 삭제된 댓글 상태 업데이트 (완전 제거 대신 isDeleted 표시)
+      setComments((prev) =>
+        prev.map((comment) => {
+          if (comment.id === commentId) {
+            return {
+              ...comment,
+              isDeleted: true,
+              deletedBy: "USER",
+              text: "삭제된 댓글입니다",
+            }
+          }
+          return {
+            ...comment,
+            replies: comment.replies.map((reply) => {
+              if (reply.id === commentId) {
+                return {
+                  ...reply,
+                  isDeleted: true,
+                  deletedBy: "USER",
+                  text: "삭제된 댓글입니다",
+                }
+              }
+              return reply
+            }),
+          }
+        })
+      )
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "삭제에 실패했습니다")
+    }
   }, [])
 
-  const deleteComment = useCallback((commentId: string) => {
-    setComments((prev) =>
-      prev
-        .filter((comment) => comment.id !== commentId)
-        .map((comment) => ({
-          ...comment,
-          replies: comment.replies.filter((reply) => reply.id !== commentId),
-        })),
-    )
+  // 사용자 차단
+  const blockUser = useCallback(async (commentId: string) => {
+    try {
+      await commentsApi.blockComment(Number(commentId))
+      // 차단 후 댓글 목록 새로고침 (백엔드에서 차단된 사용자 댓글은 "차단된 댓글입니다"로 대체됨)
+      await fetchComments(1)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "차단에 실패했습니다")
+    }
+  }, [fetchComments])
+
+  // 댓글 신고
+  const reportComment = useCallback(async (commentId: string) => {
+    try {
+      await commentsApi.reportComment(Number(commentId))
+      // 신고 성공 알림 (추후 토스트로 대체)
+      alert("신고가 접수되었습니다")
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "신고에 실패했습니다")
+    }
   }, [])
 
-  const blockUser = useCallback((commentId: string) => {
-    // TODO: API 연동 시 실제 차단 기능 구현
-    console.log("차단:", commentId)
-  }, [])
-
-  const reportComment = useCallback((commentId: string) => {
-    // TODO: API 연동 시 실제 신고 기능 구현
-    console.log("신고:", commentId)
-  }, [])
+  // 본인 댓글 여부 확인
+  const isOwnComment = useCallback((userId: number) => {
+    return currentUserId === userId
+  }, [currentUserId])
 
   return {
     comments,
@@ -189,5 +361,13 @@ export function useComments(questionId: string) {
     deleteComment,
     blockUser,
     reportComment,
+    isLoading,
+    isSubmitting,
+    error,
+    hasMore,
+    loadMore,
+    isOwnComment,
+    currentUserId,
+    refresh: () => fetchComments(1),
   }
 }

--- a/hooks/use-questions.ts
+++ b/hooks/use-questions.ts
@@ -39,6 +39,8 @@ export function toQuestion(response: QuestionResponse, isToday = false): Questio
     status: response.status,
     hasVoted: response.hasVoted,
     userChoice,
+    canViewResults: response.canViewResults ?? response.hasVoted,
+    canChangeVote: response.canChangeVote ?? true,
   }
 }
 

--- a/hooks/use-user-profile.ts
+++ b/hooks/use-user-profile.ts
@@ -37,6 +37,7 @@ export function useUserProfile() {
     engagementRate: 0,
     majorityRate: 0,
     currentStreak: 0,
+    ticketCount: 0,
     recentActivity: generateDefaultActivity(),
     bestComments: [],
   })
@@ -65,6 +66,7 @@ export function useUserProfile() {
         engagementRate: Math.round(data.stats.participationRate),
         majorityRate: Math.round(data.stats.majorityRate),
         currentStreak: data.stats.currentStreak,
+        ticketCount: data.stats.ticketCount,
         recentActivity: convertWeeklyActivity(data.stats.weeklyActivity),
         bestComments: [],
       })

--- a/lib/api/comments.ts
+++ b/lib/api/comments.ts
@@ -1,0 +1,67 @@
+import { apiGet, apiPost, apiDelete } from "@/lib/api-client"
+import type {
+  CommentResponse,
+  CommentsListResponse,
+  CreateCommentRequest,
+} from "@/types/api"
+
+const BASE_PATH = "/api/v1"
+
+/**
+ * 댓글 목록 조회
+ */
+export async function getComments(
+  questionId: number,
+  params?: { page?: number; size?: number }
+) {
+  const searchParams = new URLSearchParams()
+  if (params?.page) searchParams.set("page", String(params.page))
+  if (params?.size) searchParams.set("size", String(params.size))
+
+  const query = searchParams.toString()
+  const endpoint = `${BASE_PATH}/questions/${questionId}/comments${query ? `?${query}` : ""}`
+
+  return apiGet<CommentsListResponse>(endpoint)
+}
+
+/**
+ * 댓글 작성
+ */
+export async function createComment(data: CreateCommentRequest) {
+  return apiPost<CommentResponse>(`${BASE_PATH}/comments`, data)
+}
+
+/**
+ * 댓글 삭제
+ */
+export async function deleteComment(commentId: number) {
+  return apiDelete<null>(`${BASE_PATH}/comments/${commentId}`)
+}
+
+/**
+ * 댓글 좋아요
+ */
+export async function likeComment(commentId: number) {
+  return apiPost<null>(`${BASE_PATH}/comments/${commentId}/like`)
+}
+
+/**
+ * 댓글 좋아요 취소
+ */
+export async function unlikeComment(commentId: number) {
+  return apiDelete<null>(`${BASE_PATH}/comments/${commentId}/like`)
+}
+
+/**
+ * 댓글 신고
+ */
+export async function reportComment(commentId: number) {
+  return apiPost<null>(`${BASE_PATH}/comments/${commentId}/report`)
+}
+
+/**
+ * 댓글 차단
+ */
+export async function blockComment(commentId: number) {
+  return apiPost<null>(`${BASE_PATH}/comments/${commentId}/block`)
+}

--- a/lib/api/tickets.ts
+++ b/lib/api/tickets.ts
@@ -1,0 +1,14 @@
+// Ticket API 서비스 함수
+
+import { apiPost } from "@/lib/api-client"
+import type { TicketUseResponse } from "@/types/api"
+
+const BASE_PATH = "/api/v1/tickets"
+
+/**
+ * 열람권 사용
+ * @param questionId 열람할 질문 ID
+ */
+export async function useTicket(questionId: number) {
+  return apiPost<TicketUseResponse>(`${BASE_PATH}/use`, { questionId })
+}

--- a/types/api.ts
+++ b/types/api.ts
@@ -47,6 +47,7 @@ export interface QuestionResponse {
   userChoice: number | null
   canVote?: boolean
   canChangeVote?: boolean
+  canViewResults?: boolean
   voteStats: VoteStats | null
 }
 
@@ -119,6 +120,7 @@ export interface UserStats {
   participationRate: number
   majorityRate: number
   currentStreak: number
+  ticketCount: number
   weeklyActivity: boolean[]
 }
 
@@ -134,4 +136,69 @@ export interface UserResponse {
   isDeleted: boolean
   notificationEnabled: boolean
   stats: UserStats
+}
+
+/**
+ * 열람권 사용 응답
+ */
+export interface TicketUseResponse {
+  questionId: number
+  remainingTickets: number
+}
+
+/**
+ * 댓글 삭제 주체
+ */
+export type CommentDeletedBy = "USER" | "ADMIN" | null
+
+/**
+ * 대댓글 응답
+ */
+export interface CommentReplyResponse {
+  commentId: number
+  userId: number
+  userNickname: string
+  content: string
+  isDeleted: boolean
+  deletedBy: CommentDeletedBy
+  createdAt: string
+  likeCount: number
+  isLiked: boolean
+}
+
+/**
+ * 댓글 응답
+ */
+export interface CommentResponse {
+  commentId: number
+  questionId: number
+  parentId: number | null
+  userId: number
+  userNickname: string
+  content: string
+  isDeleted: boolean
+  deletedBy: CommentDeletedBy
+  createdAt: string
+  likeCount: number
+  isLiked: boolean
+  replies: CommentReplyResponse[]
+}
+
+/**
+ * 댓글 목록 조회 응답 (페이지 기반)
+ */
+export interface CommentsListResponse {
+  page: number
+  size: number
+  hasNext: boolean
+  items: CommentResponse[]
+}
+
+/**
+ * 댓글 작성 요청
+ */
+export interface CreateCommentRequest {
+  questionId: number
+  parentId: number | null
+  content: string
 }

--- a/types/entities.ts
+++ b/types/entities.ts
@@ -1,11 +1,17 @@
 // 핵심 도메인 엔티티 타입 정의
 
 /**
+ * 댓글 삭제 주체
+ */
+export type CommentDeletedBy = "USER" | "ADMIN" | null
+
+/**
  * 댓글 엔티티
  */
 export interface Comment {
   id: string
   author: string
+  userId: number
   avatar?: string
   date: string
   text: string
@@ -13,6 +19,9 @@ export interface Comment {
   replies: Comment[]
   userLiked?: boolean
   questionId?: string  // 프로필 베스트 댓글용
+  isDeleted: boolean
+  deletedBy: CommentDeletedBy
+  parentId: string | null
 }
 
 /**
@@ -33,4 +42,6 @@ export interface Question {
   comments?: Comment[]
   hasVoted: boolean
   userChoice: number | null
+  canViewResults?: boolean
+  canChangeVote?: boolean
 }

--- a/types/user.ts
+++ b/types/user.ts
@@ -14,6 +14,7 @@ export interface UserProfile {
   engagementRate: number
   majorityRate: number
   currentStreak: number
+  ticketCount: number
   recentActivity: ActivityItem[]
   bestComments: Comment[]
 }


### PR DESCRIPTION
## 🔗 Issue Link
<!-- 관련 이슈 번호를 적어주세요. 해당 PR merge와 함께 이슈를 닫으려면 `close #이슈번호`를 적어주세요. -->
- #25 

## 🎯 What I Did
  <!-- 이번 PR에서 구현하거나 수정한 주요 내용을 간결히 기술하세요. -->
  - 댓글 API 연동 (목록 조회, 작성, 삭제, 좋아요, 신고, 차단)
  - 삭제된 댓글 표시 처리 (USER/ADMIN 삭제 구분)
  - 댓글 중복 작성 방지 로직 추가
  - 열람권 API 연동 및 사용 모달 추가 (홈, 질문 목록)
  - 투표 수정 기능 canChangeVote 필드 적용
  - 질문 상세 페이지 레이아웃 개선 (질문 고정, 댓글 스크롤, 입력창 고정)
  - UI 색상 통일 (primary/40 테두리, primary/60 버튼)

  ## 🔍 Review Points
  <!-- 리뷰어가 집중해서 봐야 할 부분이나 검증이 필요한 로직을 적어주세요. -->
  - 댓글 API 에러 핸들링 및 낙관적 업데이트 로직 (`hooks/use-comments.ts`)
  - 열람권 사용 후 프로필 갱신 흐름 (`app/(main)/home/page.tsx`, `app/(main)/questions/page.tsx`)
  - 투표 수정 가능 여부 판단 로직 (`components/question-card.tsx`)

<!-- ## 🚀 Notes
실행, 환경 설정, 테스트에 필요한 추가 정보가 있다면 적어주세요. -->
