### PR TITLE
[Feature] 댓글/열람권 API 연동 및 UI/UX 개선

### DIFF
--- a/app/(main)/home/page.tsx
+++ b/app/(main)/home/page.tsx
@@ -5,20 +5,19 @@ import { useRouter } from "next/navigation"
 import { QuestionCard } from "@/components/question-card"
 import { LoadingSkeleton } from "@/components/loading-skeleton"
 import { PullToRefresh } from "@/components/pull-to-refresh"
+import { TicketModal } from "@/components/ticket-modal"
 import { useQuestionsContext } from "@/contexts/questions-context"
 import { useAuthContext } from "@/contexts/auth-context"
-import { useUserProfile } from "@/hooks/use-user-profile"
+import { useTicketModal } from "@/hooks/use-ticket-modal"
 import { ERROR_MESSAGES, toQuestion } from "@/hooks/use-questions"
-import { BellIcon, ChartBarIcon, TicketIcon } from "@heroicons/react/24/outline"
+import { BellIcon, ChartBarIcon } from "@heroicons/react/24/outline"
 import Link from "next/link"
 import * as questionsApi from "@/lib/api/questions"
-import * as ticketsApi from "@/lib/api/tickets"
 import type { Question } from "@/types/entities"
 
 export default function HomePage() {
   const router = useRouter()
   const { isLoading: authLoading } = useAuthContext()
-  const { profile, fetchProfile } = useUserProfile()
   const {
     todayQuestion,
     fetchTodayQuestion,
@@ -32,12 +31,17 @@ export default function HomePage() {
     refreshingId,
   } = useQuestionsContext()
 
+  const {
+    showModal,
+    isUsing,
+    ticketCount,
+    closeModal,
+    useTicket,
+    handleQuestionClick: handleTicketQuestionClick,
+  } = useTicketModal()
+
   const [topQuestions, setTopQuestions] = useState<Question[]>([])
   const [isLoadingTop, setIsLoadingTop] = useState(true)
-  const [showTicketModal, setShowTicketModal] = useState(false)
-  const [selectedClosedQuestion, setSelectedClosedQuestion] = useState<Question | null>(null)
-  const [isUsingTicket, setIsUsingTicket] = useState(false)
-  const ticketCount = profile.ticketCount
 
   // 인증 완료 후 오늘의 질문 & Top 5 로드
   useEffect(() => {
@@ -63,32 +67,7 @@ export default function HomePage() {
   }, [fetchTodayQuestion])
 
   const handleTopQuestionClick = (q: Question) => {
-    const canView = q.canViewResults ?? hasUserVoted(q.id)
-    const isClosedWithoutAccess = q.status === "CLOSED" && !canView
-
-    if (isClosedWithoutAccess) {
-      setSelectedClosedQuestion(q)
-      setShowTicketModal(true)
-    } else {
-      router.push(`/questions/${q.id}`)
-    }
-  }
-
-  const handleUseTicket = async () => {
-    if (!selectedClosedQuestion || ticketCount === 0) return
-
-    try {
-      setIsUsingTicket(true)
-      await ticketsApi.useTicket(Number(selectedClosedQuestion.id))
-      fetchProfile()
-      router.push(`/questions/${selectedClosedQuestion.id}`)
-    } catch (error) {
-      console.error("열람권 사용 실패:", error)
-    } finally {
-      setIsUsingTicket(false)
-      setShowTicketModal(false)
-      setSelectedClosedQuestion(null)
-    }
+    handleTicketQuestionClick(q, hasUserVoted(q.id))
   }
 
   const question = todayQuestion
@@ -172,65 +151,13 @@ export default function HomePage() {
           </div>
         )}
 
-        {/* 열람권 사용 확인 모달 */}
-        {showTicketModal && selectedClosedQuestion && (
-          <div className="fixed inset-0 z-50 flex items-center justify-center">
-            <div
-              className="absolute inset-0 bg-black/40"
-              onClick={() => {
-                setShowTicketModal(false)
-                setSelectedClosedQuestion(null)
-              }}
-            />
-            <div className="relative bg-card rounded-2xl border border-border p-6 mx-5 max-w-sm w-full shadow-xl">
-              <div className="flex flex-col items-center text-center">
-                <div className="w-14 h-14 bg-primary/10 rounded-full flex items-center justify-center mb-4">
-                  <TicketIcon className="w-7 h-7 text-primary" />
-                </div>
-                <h3 className="text-lg font-semibold text-foreground mb-2">
-                  열람권을 사용하시겠어요?
-                </h3>
-                <p className="text-sm text-muted-foreground mb-1">
-                  종료된 질문의 결과를 확인할 수 있어요
-                </p>
-                <p className="text-sm text-muted-foreground mb-6">
-                  보유 열람권: <span className="font-semibold text-primary">{ticketCount}개</span>
-                </p>
-                <div className="flex flex-col gap-2 w-full">
-                  <button
-                    onClick={handleUseTicket}
-                    disabled={ticketCount === 0 || isUsingTicket}
-                    className={`w-full py-3 px-4 rounded-xl font-medium text-[15px] active:scale-95 transition-transform ${
-                      ticketCount > 0 && !isUsingTicket
-                        ? "bg-primary/60 text-white"
-                        : "bg-muted text-muted-foreground cursor-not-allowed"
-                    }`}
-                  >
-                    {isUsingTicket ? (
-                      <span className="flex items-center justify-center gap-2">
-                        <span className="w-4 h-4 border-2 border-white/60 border-t-transparent rounded-full animate-spin" />
-                        사용 중...
-                      </span>
-                    ) : ticketCount > 0 ? (
-                      "열람권 사용하기"
-                    ) : (
-                      "열람권이 없어요"
-                    )}
-                  </button>
-                  <button
-                    onClick={() => {
-                      setShowTicketModal(false)
-                      setSelectedClosedQuestion(null)
-                    }}
-                    className="w-full py-3 px-4 bg-muted text-muted-foreground rounded-xl font-medium text-[15px] active:scale-95 transition-transform"
-                  >
-                    취소
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        )}
+        <TicketModal
+          isOpen={showModal}
+          ticketCount={ticketCount}
+          isUsing={isUsing}
+          onUse={useTicket}
+          onClose={closeModal}
+        />
       </div>
     )
   }
@@ -300,65 +227,13 @@ export default function HomePage() {
         </div>
       )}
 
-      {/* 열람권 사용 확인 모달 */}
-      {showTicketModal && selectedClosedQuestion && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center">
-          <div
-            className="absolute inset-0 bg-black/40"
-            onClick={() => {
-              setShowTicketModal(false)
-              setSelectedClosedQuestion(null)
-            }}
-          />
-          <div className="relative bg-card rounded-2xl border border-border p-6 mx-5 max-w-sm w-full shadow-xl">
-            <div className="flex flex-col items-center text-center">
-              <div className="w-14 h-14 bg-primary/10 rounded-full flex items-center justify-center mb-4">
-                <TicketIcon className="w-7 h-7 text-primary" />
-              </div>
-              <h3 className="text-lg font-semibold text-foreground mb-2">
-                열람권을 사용하시겠어요?
-              </h3>
-              <p className="text-sm text-muted-foreground mb-1">
-                종료된 질문의 결과를 확인할 수 있어요
-              </p>
-              <p className="text-sm text-muted-foreground mb-6">
-                보유 열람권: <span className="font-semibold text-primary">{ticketCount}개</span>
-              </p>
-              <div className="flex flex-col gap-2 w-full">
-                <button
-                  onClick={handleUseTicket}
-                  disabled={ticketCount === 0 || isUsingTicket}
-                  className={`w-full py-3 px-4 rounded-xl font-medium text-[15px] active:scale-95 transition-transform ${
-                    ticketCount > 0 && !isUsingTicket
-                      ? "bg-primary/60 text-white"
-                      : "bg-muted text-muted-foreground cursor-not-allowed"
-                  }`}
-                >
-                  {isUsingTicket ? (
-                    <span className="flex items-center justify-center gap-2">
-                      <span className="w-4 h-4 border-2 border-white/60 border-t-transparent rounded-full animate-spin" />
-                      사용 중...
-                    </span>
-                  ) : ticketCount > 0 ? (
-                    "열람권 사용하기"
-                  ) : (
-                    "열람권이 없어요"
-                  )}
-                </button>
-                <button
-                  onClick={() => {
-                    setShowTicketModal(false)
-                    setSelectedClosedQuestion(null)
-                  }}
-                  className="w-full py-3 px-4 bg-muted text-muted-foreground rounded-xl font-medium text-[15px] active:scale-95 transition-transform"
-                >
-                  취소
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
+      <TicketModal
+        isOpen={showModal}
+        ticketCount={ticketCount}
+        isUsing={isUsing}
+        onUse={useTicket}
+        onClose={closeModal}
+      />
     </div>
     </PullToRefresh>
   )

--- a/app/(main)/questions/page.tsx
+++ b/app/(main)/questions/page.tsx
@@ -1,25 +1,18 @@
 "use client"
 
-import { useEffect, useRef, useCallback, useState } from "react"
-import { useRouter } from "next/navigation"
+import { useEffect, useRef, useCallback } from "react"
 import { QuestionCard } from "@/components/question-card"
 import { LoadingSkeleton } from "@/components/loading-skeleton"
 import { PullToRefresh } from "@/components/pull-to-refresh"
+import { TicketModal } from "@/components/ticket-modal"
 import { useQuestionsContext } from "@/contexts/questions-context"
 import { useAuthContext } from "@/contexts/auth-context"
-import { useUserProfile } from "@/hooks/use-user-profile"
-import { ChatBubbleOvalLeftEllipsisIcon, TicketIcon } from "@heroicons/react/24/outline"
-import * as ticketsApi from "@/lib/api/tickets"
+import { useTicketModal } from "@/hooks/use-ticket-modal"
+import { ChatBubbleOvalLeftEllipsisIcon } from "@heroicons/react/24/outline"
 import type { Question } from "@/types/entities"
 
 export default function QuestionsPage() {
-  const router = useRouter()
   const { isLoading: authLoading } = useAuthContext()
-  const { profile, fetchProfile } = useUserProfile()
-  const [showTicketModal, setShowTicketModal] = useState(false)
-  const [selectedClosedQuestion, setSelectedClosedQuestion] = useState<Question | null>(null)
-  const [isUsingTicket, setIsUsingTicket] = useState(false)
-  const ticketCount = profile.ticketCount
   const {
     todayQuestion,
     pastQuestions,
@@ -35,6 +28,15 @@ export default function QuestionsPage() {
     refreshQuestion,
     refreshingId,
   } = useQuestionsContext()
+
+  const {
+    showModal,
+    isUsing,
+    ticketCount,
+    closeModal,
+    useTicket,
+    handleQuestionClick: handleTicketQuestionClick,
+  } = useTicketModal()
 
   // 무한스크롤을 위한 observer ref
   const observerTarget = useRef<HTMLDivElement>(null)
@@ -75,34 +77,7 @@ export default function QuestionsPage() {
     : pastQuestions
 
   const handleQuestionClick = (question: Question) => {
-    const canView = question.canViewResults ?? hasUserVoted(question.id)
-    const isClosedWithoutAccess = question.status === "CLOSED" && !canView
-
-    if (isClosedWithoutAccess) {
-      setSelectedClosedQuestion(question)
-      setShowTicketModal(true)
-    } else {
-      router.push(`/questions/${question.id}`)
-    }
-  }
-
-  const handleUseTicket = async () => {
-    if (!selectedClosedQuestion || ticketCount === 0) return
-
-    try {
-      setIsUsingTicket(true)
-      await ticketsApi.useTicket(Number(selectedClosedQuestion.id))
-      // 열람권 사용 후 프로필 갱신 (ticketCount 업데이트)
-      fetchProfile()
-      router.push(`/questions/${selectedClosedQuestion.id}`)
-    } catch (error) {
-      console.error("열람권 사용 실패:", error)
-      // TODO: 에러 토스트 표시
-    } finally {
-      setIsUsingTicket(false)
-      setShowTicketModal(false)
-      setSelectedClosedQuestion(null)
-    }
+    handleTicketQuestionClick(question, hasUserVoted(question.id))
   }
 
   const handlePullRefresh = useCallback(async () => {
@@ -175,72 +150,14 @@ export default function QuestionsPage() {
         </div>
       )}
 
+      <TicketModal
+        isOpen={showModal}
+        ticketCount={ticketCount}
+        isUsing={isUsing}
+        onUse={useTicket}
+        onClose={closeModal}
+      />
     </div>
-
-      {/* 열람권 사용 확인 모달 */}
-      {showTicketModal && selectedClosedQuestion && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center">
-          {/* 배경 오버레이 */}
-          <div
-            className="absolute inset-0 bg-black/40"
-            onClick={() => {
-              setShowTicketModal(false)
-              setSelectedClosedQuestion(null)
-            }}
-          />
-
-          {/* 모달 */}
-          <div className="relative bg-card rounded-2xl border border-border p-6 mx-5 max-w-sm w-full shadow-xl">
-            <div className="flex flex-col items-center text-center">
-              <div className="w-14 h-14 bg-primary/10 rounded-full flex items-center justify-center mb-4">
-                <TicketIcon className="w-7 h-7 text-primary" />
-              </div>
-
-              <h3 className="text-lg font-semibold text-foreground mb-2">
-                열람권을 사용하시겠어요?
-              </h3>
-              <p className="text-sm text-muted-foreground mb-1">
-                종료된 질문의 결과를 확인할 수 있어요
-              </p>
-              <p className="text-sm text-muted-foreground mb-6">
-                보유 열람권: <span className="font-semibold text-primary">{ticketCount}개</span>
-              </p>
-
-              <div className="flex flex-col gap-2 w-full">
-                <button
-                  onClick={handleUseTicket}
-                  disabled={ticketCount === 0 || isUsingTicket}
-                  className={`w-full py-3 px-4 rounded-xl font-medium text-[15px] active:scale-95 transition-transform ${
-                    ticketCount > 0 && !isUsingTicket
-                      ? "bg-primary/60 text-white"
-                      : "bg-muted text-muted-foreground cursor-not-allowed"
-                  }`}
-                >
-                  {isUsingTicket ? (
-                    <span className="flex items-center justify-center gap-2">
-                      <span className="w-4 h-4 border-2 border-white/60 border-t-transparent rounded-full animate-spin" />
-                      사용 중...
-                    </span>
-                  ) : ticketCount > 0 ? (
-                    "열람권 사용하기"
-                  ) : (
-                    "열람권이 없어요"
-                  )}
-                </button>
-                <button
-                  onClick={() => {
-                    setShowTicketModal(false)
-                    setSelectedClosedQuestion(null)
-                  }}
-                  className="w-full py-3 px-4 bg-muted text-muted-foreground rounded-xl font-medium text-[15px] active:scale-95 transition-transform"
-                >
-                  취소
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
     </PullToRefresh>
   )
 }

--- a/components/ticket-modal.tsx
+++ b/components/ticket-modal.tsx
@@ -1,0 +1,74 @@
+"use client"
+
+import { TicketIcon } from "@heroicons/react/24/outline"
+
+interface TicketModalProps {
+  isOpen: boolean
+  ticketCount: number
+  isUsing: boolean
+  onUse: () => void
+  onClose: () => void
+}
+
+export function TicketModal({
+  isOpen,
+  ticketCount,
+  isUsing,
+  onUse,
+  onClose,
+}: TicketModalProps) {
+  if (!isOpen) return null
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div
+        className="absolute inset-0 bg-black/40"
+        onClick={onClose}
+      />
+      <div className="relative bg-card rounded-2xl border border-border p-6 mx-5 max-w-sm w-full shadow-xl">
+        <div className="flex flex-col items-center text-center">
+          <div className="w-14 h-14 bg-primary/10 rounded-full flex items-center justify-center mb-4">
+            <TicketIcon className="w-7 h-7 text-primary" />
+          </div>
+          <h3 className="text-lg font-semibold text-foreground mb-2">
+            열람권을 사용하시겠어요?
+          </h3>
+          <p className="text-sm text-muted-foreground mb-1">
+            종료된 질문의 결과를 확인할 수 있어요
+          </p>
+          <p className="text-sm text-muted-foreground mb-6">
+            보유 열람권: <span className="font-semibold text-primary">{ticketCount}개</span>
+          </p>
+          <div className="flex flex-col gap-2 w-full">
+            <button
+              onClick={onUse}
+              disabled={ticketCount === 0 || isUsing}
+              className={`w-full py-3 px-4 rounded-xl font-medium text-[15px] active:scale-95 transition-transform ${
+                ticketCount > 0 && !isUsing
+                  ? "bg-primary/60 text-white"
+                  : "bg-muted text-muted-foreground cursor-not-allowed"
+              }`}
+            >
+              {isUsing ? (
+                <span className="flex items-center justify-center gap-2">
+                  <span className="w-4 h-4 border-2 border-white/60 border-t-transparent rounded-full animate-spin" />
+                  사용 중...
+                </span>
+              ) : ticketCount > 0 ? (
+                "열람권 사용하기"
+              ) : (
+                "열람권이 없어요"
+              )}
+            </button>
+            <button
+              onClick={onClose}
+              className="w-full py-3 px-4 bg-muted text-muted-foreground rounded-xl font-medium text-[15px] active:scale-95 transition-transform"
+            >
+              취소
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/hooks/use-comments.ts
+++ b/hooks/use-comments.ts
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState, useCallback, useEffect, useRef } from "react"
+import { toast } from "sonner"
 import { Comment } from "@/types/entities"
 import type { CommentResponse, CommentReplyResponse } from "@/types/api"
 import * as commentsApi from "@/lib/api/comments"
@@ -165,18 +166,13 @@ export function useComments(questionId: string) {
       })
 
       const newReply = toComment(response.data)
-      // replies 배열이 빈 배열로 오므로, toReplyComment 형태로 변환
-      const replyComment: Comment = {
-        ...newReply,
-        parentId,
-      }
 
       setComments((prev) =>
         prev.map((comment) => {
           if (comment.id === parentId) {
             return {
               ...comment,
-              replies: [...comment.replies, replyComment],
+              replies: [...comment.replies, newReply],
             }
           }
           return comment
@@ -335,10 +331,9 @@ export function useComments(questionId: string) {
   const reportComment = useCallback(async (commentId: string) => {
     try {
       await commentsApi.reportComment(Number(commentId))
-      // 신고 성공 알림 (추후 토스트로 대체)
-      alert("신고가 접수되었습니다")
+      toast.success("신고가 접수되었습니다")
     } catch (err) {
-      setError(err instanceof Error ? err.message : "신고에 실패했습니다")
+      toast.error("신고에 실패했습니다")
     }
   }, [])
 

--- a/hooks/use-ticket-modal.ts
+++ b/hooks/use-ticket-modal.ts
@@ -1,0 +1,67 @@
+"use client"
+
+import { useState, useCallback } from "react"
+import { useRouter } from "next/navigation"
+import { toast } from "sonner"
+import { useUserProfile } from "@/hooks/use-user-profile"
+import * as ticketsApi from "@/lib/api/tickets"
+import type { Question } from "@/types/entities"
+
+export function useTicketModal() {
+  const router = useRouter()
+  const { profile, fetchProfile } = useUserProfile()
+  const [showModal, setShowModal] = useState(false)
+  const [selectedQuestion, setSelectedQuestion] = useState<Question | null>(null)
+  const [isUsing, setIsUsing] = useState(false)
+
+  const ticketCount = profile.ticketCount
+
+  const openModal = useCallback((question: Question) => {
+    setSelectedQuestion(question)
+    setShowModal(true)
+  }, [])
+
+  const closeModal = useCallback(() => {
+    setShowModal(false)
+    setSelectedQuestion(null)
+  }, [])
+
+  const useTicket = useCallback(async () => {
+    if (!selectedQuestion || ticketCount === 0) return
+
+    try {
+      setIsUsing(true)
+      await ticketsApi.useTicket(Number(selectedQuestion.id))
+      fetchProfile()
+      router.push(`/questions/${selectedQuestion.id}`)
+    } catch (error) {
+      toast.error("열람권 사용에 실패했습니다")
+    } finally {
+      setIsUsing(false)
+      closeModal()
+    }
+  }, [selectedQuestion, ticketCount, fetchProfile, router, closeModal])
+
+  // 질문 클릭 핸들러 - 종료된 질문이면 모달 표시, 아니면 이동
+  const handleQuestionClick = useCallback((question: Question, hasVoted: boolean) => {
+    const canView = question.canViewResults ?? hasVoted
+    const isClosedWithoutAccess = question.status === "CLOSED" && !canView
+
+    if (isClosedWithoutAccess) {
+      openModal(question)
+    } else {
+      router.push(`/questions/${question.id}`)
+    }
+  }, [openModal, router])
+
+  return {
+    showModal,
+    selectedQuestion,
+    isUsing,
+    ticketCount,
+    openModal,
+    closeModal,
+    useTicket,
+    handleQuestionClick,
+  }
+}

--- a/types/api.ts
+++ b/types/api.ts
@@ -1,5 +1,7 @@
 // 백엔드 API 응답 타입 정의
 
+import type { CommentDeletedBy } from "./entities"
+
 /**
  * 질문 상태
  */
@@ -145,11 +147,6 @@ export interface TicketUseResponse {
   questionId: number
   remainingTickets: number
 }
-
-/**
- * 댓글 삭제 주체
- */
-export type CommentDeletedBy = "USER" | "ADMIN" | null
 
 /**
  * 대댓글 응답


### PR DESCRIPTION
## 🔗 Issue Link
<!-- 관련 이슈 번호를 적어주세요. 해당 PR merge와 함께 이슈를 닫으려면 `close #이슈번호`를 적어주세요. -->
- #25 

## 🎯 What I Did
  <!-- 이번 PR에서 구현하거나 수정한 주요 내용을 간결히 기술하세요. -->
  - 댓글 API 연동 (목록 조회, 작성, 삭제, 좋아요, 신고, 차단)
  - 삭제된 댓글 표시 처리 (USER/ADMIN 삭제 구분)
  - 댓글 중복 작성 방지 로직 추가
  - 열람권 API 연동 및 사용 모달 추가 (홈, 질문 목록)
  - 투표 수정 기능 canChangeVote 필드 적용
  - 질문 상세 페이지 레이아웃 개선 (질문 고정, 댓글 스크롤, 입력창 고정)
  - UI 색상 통일 (primary/40 테두리, primary/60 버튼)

  ## 🔍 Review Points
  <!-- 리뷰어가 집중해서 봐야 할 부분이나 검증이 필요한 로직을 적어주세요. -->
  - 댓글 API 에러 핸들링 및 낙관적 업데이트 로직 (`hooks/use-comments.ts`)
  - 열람권 사용 후 프로필 갱신 흐름 (`app/(main)/home/page.tsx`, `app/(main)/questions/page.tsx`)
  - 투표 수정 가능 여부 판단 로직 (`components/question-card.tsx`)

<!-- ## 🚀 Notes
실행, 환경 설정, 테스트에 필요한 추가 정보가 있다면 적어주세요. -->
