### PR TITLE
[Feature] FCM 토큰 변경 감지를 위한 리스너 추가

### DIFF
--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -80,6 +80,29 @@ firebase.initializeApp({
 
 const messaging = firebase.messaging();
 
+// FCM 토큰 갱신 감지 (Service Worker)
+messaging.onTokenRefresh(async () => {
+  try {
+    console.log('FCM 토큰 갱신 이벤트 발생');
+    const newToken = await messaging.getToken();
+
+    if (newToken) {
+      console.log('새로운 FCM 토큰:', newToken);
+
+      // 클라이언트에 토큰 갱신 알림
+      const clients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
+      clients.forEach(client => {
+        client.postMessage({
+          type: 'FCM_TOKEN_REFRESHED',
+          token: newToken
+        });
+      });
+    }
+  } catch (error) {
+    console.error('토큰 갱신 중 오류:', error);
+  }
+});
+
 // 백그라운드 푸시 알림 수신
 messaging.onBackgroundMessage((payload) => {
   console.log('백그라운드 메시지 수신:', payload);

--- a/src/components/FCMInitializer.tsx
+++ b/src/components/FCMInitializer.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import { requestFCMToken, onForegroundMessage } from '@/src/lib/fcmTokenManager';
+import { requestFCMToken, onForegroundMessage, setupTokenRefreshListener } from '@/src/lib/fcmTokenManager';
 import { useAuthContext } from '@/contexts/auth-context';
 
 export default function FCMInitializer() {
@@ -54,6 +54,7 @@ export default function FCMInitializer() {
     }
 
     let unsubscribe: (() => void) | null = null;
+    let cleanupTokenRefresh: (() => void) | null = null;
 
     // FCM 초기화 (Service Worker 등록 후 토큰 발급)
     const initFCM = async () => {
@@ -81,7 +82,12 @@ export default function FCMInitializer() {
 
         if (token) {
           console.log('FCM 초기화 완료');
+
+          // 포그라운드 메시지 리스너 등록
           unsubscribe = await onForegroundMessage();
+
+          // 토큰 갱신 리스너 등록
+          cleanupTokenRefresh = await setupTokenRefreshListener(accessToken);
         } else {
           console.log('FCM 초기화 실패 (권한 거부 또는 미지원 브라우저)');
         }
@@ -97,6 +103,9 @@ export default function FCMInitializer() {
     return () => {
       if (unsubscribe) {
         unsubscribe();
+      }
+      if (cleanupTokenRefresh) {
+        cleanupTokenRefresh();
       }
     };
   }, [accessToken, isAuthenticated]);

--- a/src/lib/fcmTokenManager.ts
+++ b/src/lib/fcmTokenManager.ts
@@ -88,6 +88,8 @@ export const requestFCMToken = async (accessToken?: string | null) => {
 
       if (token) {
         console.log("FCM 토큰 발급 성공:", token);
+        // localStorage에 토큰 저장 (갱신 감지용)
+        localStorage.setItem("fcm_token", token);
         await saveTokenToServer(token, accessToken);
         return token;
       } else {
@@ -182,4 +184,68 @@ export const onForegroundMessage = async () => {
   });
 
   return unsubscribe;
+};
+
+/**
+ * FCM 토큰 갱신 리스너 등록
+ * 토큰이 자동으로 갱신되는 경우:
+ * 1. 앱이 백업에서 복원된 경우
+ * 2. 사용자가 앱 데이터를 삭제한 경우
+ * 3. 사용자가 앱을 재설치한 경우
+ * 4. Firebase에서 보안상의 이유로 토큰을 갱신한 경우
+ */
+export const setupTokenRefreshListener = async (accessToken?: string | null) => {
+  try {
+    const messagingInstance = await messaging();
+    if (!messagingInstance) {
+      console.log("Firebase Messaging 초기화 실패 - 토큰 갱신 리스너 등록 불가");
+      return null;
+    }
+
+    // Service Worker 메시지 리스너 등록 (토큰 갱신 감지)
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.addEventListener('message', async (event) => {
+        if (event.data?.type === 'FCM_TOKEN_REFRESHED') {
+          const newToken = event.data.token;
+          console.log("FCM 토큰 갱신 감지:", newToken);
+
+          // 서버에 새 토큰 업데이트
+          await saveTokenToServer(newToken, accessToken);
+        }
+      });
+
+      console.log("FCM 토큰 갱신 리스너 등록 완료");
+    }
+
+    // 주기적으로 토큰 검증 및 갱신 (10분마다)
+    // Firebase onTokenRefresh가 놓칠 수 있는 edge case 대비
+    const tokenRefreshInterval = setInterval(async () => {
+      try {
+        const currentToken = await getToken(messagingInstance, {
+          vapidKey: VAPID_KEY,
+        });
+
+        if (currentToken) {
+          // localStorage에 저장된 마지막 토큰과 비교
+          const lastToken = localStorage.getItem("fcm_token");
+
+          if (lastToken !== currentToken) {
+            console.log("FCM 토큰 변경 감지 (주기적 검증) - 서버 업데이트");
+            localStorage.setItem("fcm_token", currentToken);
+            await saveTokenToServer(currentToken, accessToken);
+          }
+        }
+      } catch (error: any) {
+        console.error("토큰 갱신 검증 실패:", error?.message || error);
+      }
+    }, 10 * 60 * 1000); // 10분 (600초)
+
+    // Cleanup 함수 반환
+    return () => {
+      clearInterval(tokenRefreshInterval);
+    };
+  } catch (error: any) {
+    console.error("토큰 갱신 리스너 등록 실패:", error?.message || error);
+    return null;
+  }
 };


### PR DESCRIPTION
## 🔗 Issue Link
<!-- 관련 이슈 번호를 적어주세요. 해당 PR merge와 함께 이슈를 닫으려면 `close #이슈번호`를 적어주세요. -->
#30 

## 🎯 What I Did
<!-- 이번 PR에서 구현하거나 수정한 주요 내용을 간결히 기술하세요. -->
### Firebase가 토큰을 갱신할 때 자동으로 감지하여 서버 DB에 최신 토큰 업데이트
- Service Worker의 onTokenRefresh 이벤트 감지
- 10분마다 주기적 검증 (Firebase 이벤트 누락 대비)
- localStorage 기반 토큰 변경 감지