### PR TITLE
[Feature] 디바이스 알림 설정 조회 API 연동 및 코드 리뷰 반영 (FCM 토큰 갱신 리스너) 

### DIFF
--- a/app/(main)/settings/page.tsx
+++ b/app/(main)/settings/page.tsx
@@ -28,6 +28,7 @@ export default function SettingsPage() {
       // 서버의 실제 설정값으로 토글 동기화
       setNotificationsEnabled(settings.notificationEnabled)
       console.log("알림 설정 조회 성공:", settings.notificationEnabled)
+      return settings
     } catch (error: any) {
       const errorMessage = error?.message || "알림 설정 조회 실패"
       console.error("알림 설정 조회 오류:", errorMessage, error)
@@ -36,6 +37,7 @@ export default function SettingsPage() {
       if (typeof window !== "undefined" && "Notification" in window) {
         setNotificationsEnabled(Notification.permission === "granted")
       }
+      return null
     }
   }
 
@@ -44,10 +46,10 @@ export default function SettingsPage() {
     loadNotificationSettings()
   }, [])
 
-  // 페이지 포커스 시 DB 값 조회하여 토글 동기화 + 브라우저 권한 동기화
+  // 브라우저 권한 동기화 
   useEffect(() => {
     let isSyncing = false
-    let lastBrowserPermission = Notification.permission // 이전 브라우저 권한 상태 저장
+    let lastBrowserPermission = Notification.permission
 
     const syncBrowserPermission = async () => {
       if (!('Notification' in window) || isSyncing) return
@@ -60,9 +62,8 @@ export default function SettingsPage() {
 
         console.log('[권한 동기화] 브라우저 권한:', currentBrowserPermission, permissionChanged ? '(변경됨)' : '')
 
-        // DB 값 조회 (loadNotificationSettings가 setNotificationsEnabled 호출)
-        await loadNotificationSettings()
-        const serverSettings = await getDeviceNotificationSettings(deviceId)
+        const serverSettings = await loadNotificationSettings()
+        if (!serverSettings) return
 
         // 브라우저 권한 차단 + DB true → DB false로 업데이트
         if (currentBrowserPermission === 'denied' && serverSettings.notificationEnabled) {
@@ -95,7 +96,7 @@ export default function SettingsPage() {
     // 초기 동기화
     syncBrowserPermission()
 
-    // 이벤트 리스너: 탭 전환, 창 포커스 시 동기화
+    // 이벤트 리스너: 탭 전환, 창 포커스, Permissions API
     const handleVisibilityChange = () => {
       if (document.visibilityState === 'visible') syncBrowserPermission()
     }
@@ -104,35 +105,37 @@ export default function SettingsPage() {
     document.addEventListener('visibilitychange', handleVisibilityChange)
     window.addEventListener('focus', handleWindowFocus)
 
-    // Permissions API로 권한 변경 즉각 감지 (지원 브라우저)
     if ('permissions' in navigator && 'query' in navigator.permissions) {
       navigator.permissions.query({ name: 'notifications' as PermissionName })
         .then((status) => status.addEventListener('change', syncBrowserPermission))
         .catch(() => {})
     }
 
-    // 모달 열려있을 때만 폴링 (폴백)
-    let pollInterval: NodeJS.Timeout | null = null
-    if (showPermissionModal) {
-      setIsCheckingPermission(true)
-
-      pollInterval = setInterval(() => {
-        if (Notification.permission === 'granted' && !isSyncing) {
-          clearInterval(pollInterval!)
-          setIsCheckingPermission(false)
-          syncBrowserPermission()
-        }
-      }, 200)
-    } else {
-      setIsCheckingPermission(false)
-    }
-
     return () => {
       document.removeEventListener('visibilitychange', handleVisibilityChange)
       window.removeEventListener('focus', handleWindowFocus)
-      if (pollInterval) clearInterval(pollInterval)
     }
   }, [showPermissionModal, accessToken])
+
+  // 모달 열려있을 때 폴링 (폴백)
+  useEffect(() => {
+    if (!showPermissionModal) {
+      setIsCheckingPermission(false)
+      return
+    }
+
+    setIsCheckingPermission(true)
+
+    const pollInterval = setInterval(() => {
+      if (Notification.permission === 'granted') {
+        clearInterval(pollInterval)
+        setIsCheckingPermission(false)
+        loadNotificationSettings()
+      }
+    }, 200)
+
+    return () => clearInterval(pollInterval)
+  }, [showPermissionModal])
 
   // 알림 설정 토글 변경 핸들러
   const handleNotificationToggle = async (enabled: boolean) => {

--- a/app/(main)/settings/page.tsx
+++ b/app/(main)/settings/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { ArrowLeftIcon, ArrowLeftStartOnRectangleIcon, TrashIcon, ArrowRightOnRectangleIcon, BellIcon, Cog6ToothIcon } from "@heroicons/react/24/outline"
+import { ArrowLeftIcon, ArrowLeftStartOnRectangleIcon, TrashIcon, ArrowRightOnRectangleIcon, BellIcon } from "@heroicons/react/24/outline"
 import { Switch } from "@/components/ui/switch"
 import { useState, useEffect } from "react"
 import { useAuthContext } from "@/contexts/auth-context"
@@ -19,33 +19,35 @@ export default function SettingsPage() {
   const [showPermissionModal, setShowPermissionModal] = useState(false)
   const [isCheckingPermission, setIsCheckingPermission] = useState(false)
 
-  // 페이지 로드 시 서버에서 알림 설정 조회
-  useEffect(() => {
-    const loadNotificationSettings = async () => {
-      try {
-        const deviceId = getOrCreateDeviceId()
-        const settings = await getDeviceNotificationSettings(deviceId)
+  // 서버에서 알림 설정 조회 및 토글 동기화
+  const loadNotificationSettings = async () => {
+    try {
+      const deviceId = getOrCreateDeviceId()
+      const settings = await getDeviceNotificationSettings(deviceId)
 
-        // 서버의 실제 설정값으로 초기화
-        setNotificationsEnabled(settings.notificationEnabled)
-        console.log("알림 설정 조회 성공:", settings.notificationEnabled)
-      } catch (error: any) {
-        const errorMessage = error?.message || "알림 설정 조회 실패"
-        console.error("알림 설정 조회 오류:", errorMessage, error)
+      // 서버의 실제 설정값으로 토글 동기화
+      setNotificationsEnabled(settings.notificationEnabled)
+      console.log("알림 설정 조회 성공:", settings.notificationEnabled)
+    } catch (error: any) {
+      const errorMessage = error?.message || "알림 설정 조회 실패"
+      console.error("알림 설정 조회 오류:", errorMessage, error)
 
-        // 실패 시 브라우저 권한 상태로 폴백
-        if (typeof window !== "undefined" && "Notification" in window) {
-          setNotificationsEnabled(Notification.permission === "granted")
-        }
+      // 실패 시 브라우저 권한 상태로 폴백
+      if (typeof window !== "undefined" && "Notification" in window) {
+        setNotificationsEnabled(Notification.permission === "granted")
       }
     }
+  }
 
+  // 페이지 로드 시 초기 조회
+  useEffect(() => {
     loadNotificationSettings()
   }, [])
 
-  // 페이지 포커스 시 브라우저 권한과 서버 상태 동기화
+  // 페이지 포커스 시 DB 값 조회하여 토글 동기화 + 브라우저 권한 동기화
   useEffect(() => {
     let isSyncing = false
+    let lastBrowserPermission = Notification.permission // 이전 브라우저 권한 상태 저장
 
     const syncBrowserPermission = async () => {
       if (!('Notification' in window) || isSyncing) return
@@ -53,32 +55,36 @@ export default function SettingsPage() {
       isSyncing = true
       try {
         const deviceId = getOrCreateDeviceId()
-        const browserGranted = Notification.permission === 'granted'
+        const currentBrowserPermission = Notification.permission
+        const permissionChanged = lastBrowserPermission !== currentBrowserPermission
+
+        console.log('[권한 동기화] 브라우저 권한:', currentBrowserPermission, permissionChanged ? '(변경됨)' : '')
+
+        // DB 값 조회 (loadNotificationSettings가 setNotificationsEnabled 호출)
+        await loadNotificationSettings()
         const serverSettings = await getDeviceNotificationSettings(deviceId)
 
-        // 브라우저 권한과 서버 상태가 불일치하면 동기화
-        if (browserGranted !== serverSettings.notificationEnabled) {
-          console.log('[권한 동기화]', browserGranted ? '허용됨' : '차단됨')
+        // 브라우저 권한 차단 + DB true → DB false로 업데이트
+        if (currentBrowserPermission === 'denied' && serverSettings.notificationEnabled) {
+          console.log('[권한 동기화] 브라우저 차단 → DB false 업데이트')
+          await updateDeviceNotificationSettings(deviceId, false)
+          setNotificationsEnabled(false)
+        }
 
-          // 권한 허용 시 FCM 토큰 재발급
-          if (browserGranted) {
-            const token = await requestFCMToken(accessToken)
-            if (token) {
-              await onForegroundMessage()
-              await setupTokenRefreshListener(accessToken)
-            }
-          }
+        // 브라우저 권한 허용 + DB false + 권한 변경됨 → DB true로 업데이트
+        if (currentBrowserPermission === 'granted' && !serverSettings.notificationEnabled && permissionChanged) {
+          console.log('[권한 동기화] 브라우저 허용 감지 → DB true 업데이트')
+          await updateDeviceNotificationSettings(deviceId, true)
+          setNotificationsEnabled(true)
 
-          await updateDeviceNotificationSettings(deviceId, browserGranted)
-          setNotificationsEnabled(browserGranted)
-
-          // 모달 자동 닫기
-          if (browserGranted && showPermissionModal) {
+          if (showPermissionModal) {
             setShowPermissionModal(false)
             setIsCheckingPermission(false)
             toast.success('알림이 활성화되었습니다')
           }
         }
+
+        lastBrowserPermission = currentBrowserPermission
       } catch (error: any) {
         console.error('[권한 동기화 실패]', error?.message || error)
       } finally {
@@ -89,23 +95,19 @@ export default function SettingsPage() {
     // 초기 동기화
     syncBrowserPermission()
 
-    // 페이지 포커스 시 동기화 (visibilitychange로 충분)
+    // 이벤트 리스너: 탭 전환, 창 포커스 시 동기화
     const handleVisibilityChange = () => {
-      if (document.visibilityState === 'visible') {
-        syncBrowserPermission()
-      }
+      if (document.visibilityState === 'visible') syncBrowserPermission()
     }
-    document.addEventListener('visibilitychange', handleVisibilityChange)
+    const handleWindowFocus = () => syncBrowserPermission()
 
-    // Permissions API로 즉각 감지 (지원 브라우저)
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+    window.addEventListener('focus', handleWindowFocus)
+
+    // Permissions API로 권한 변경 즉각 감지 (지원 브라우저)
     if ('permissions' in navigator && 'query' in navigator.permissions) {
       navigator.permissions.query({ name: 'notifications' as PermissionName })
-        .then((status) => {
-          status.addEventListener('change', () => {
-            console.log('[Permissions API] 권한 변경:', status.state)
-            syncBrowserPermission()
-          })
-        })
+        .then((status) => status.addEventListener('change', syncBrowserPermission))
         .catch(() => {})
     }
 
@@ -127,6 +129,7 @@ export default function SettingsPage() {
 
     return () => {
       document.removeEventListener('visibilitychange', handleVisibilityChange)
+      window.removeEventListener('focus', handleWindowFocus)
       if (pollInterval) clearInterval(pollInterval)
     }
   }, [showPermissionModal, accessToken])
@@ -139,46 +142,37 @@ export default function SettingsPage() {
       const deviceId = getOrCreateDeviceId()
 
       if (enabled) {
-        // 알림 켜기: 브라우저 권한 확인 후 서버 업데이트
-        console.log("알림 권한 확인 중...")
         const currentPermission = Notification.permission
 
         if (currentPermission === "granted") {
-          // 이미 권한이 허용되어 있으면 바로 API 호출
-          setNotificationsEnabled(true)
+          // 권한 허용됨 → DB 업데이트
           await updateDeviceNotificationSettings(deviceId, true)
-          console.log("알림 설정 업데이트 성공: true (기존 권한 사용)")
+          setNotificationsEnabled(true)
         } else if (currentPermission === "denied") {
-          // 권한이 차단된 경우 - 안내 모달 표시
-          setNotificationsEnabled(false)
+          // 권한 차단됨 → 안내 모달 표시
           setShowPermissionModal(true)
-          console.log("알림 권한이 차단되어 있음 (denied) - 모달 표시")
         } else {
-          // 권한이 아직 결정되지 않은 경우 (default) - 권한 요청
+          // 권한 미결정 → 권한 요청
           const permission = await Notification.requestPermission()
-          console.log("사용자 선택:", permission)
 
           if (permission === "granted") {
-            // 권한 허용 시
-            setNotificationsEnabled(true)
+            const token = await requestFCMToken(accessToken)
+            if (token) {
+              await onForegroundMessage()
+              await setupTokenRefreshListener(accessToken)
+            }
             await updateDeviceNotificationSettings(deviceId, true)
-            console.log("알림 설정 업데이트 성공: true (새 권한 허용)")
-          } else {
-            // 권한 거부 시
-            setNotificationsEnabled(false)
-            console.log("사용자가 알림 권한을 거부했습니다")
+            setNotificationsEnabled(true)
           }
         }
       } else {
-        // 알림 끄기: 서버에 알림 비활성화 요청
-        setNotificationsEnabled(false)
+        // 알림 끄기
         await updateDeviceNotificationSettings(deviceId, false)
-        console.log("알림 설정 업데이트 성공: false")
+        setNotificationsEnabled(false)
       }
     } catch (error: any) {
       const errorMessage = error?.message || "알림 설정 업데이트에 실패했습니다"
       console.error("알림 설정 업데이트 실패:", errorMessage, error)
-      // 실패 시 원래 상태로 복구
       setNotificationsEnabled(!enabled)
       toast.error(errorMessage)
     } finally {
@@ -342,16 +336,6 @@ export default function SettingsPage() {
                   </div>
                 </div>
               </div>
-
-              {/* 권한 확인 중 표시 */}
-              {isCheckingPermission && (
-                <div className="w-full bg-primary/10 rounded-xl p-3 mb-4 flex items-center gap-3">
-                  <div className="w-5 h-5 border-2 border-primary border-t-transparent rounded-full animate-spin" />
-                  <p className="text-sm text-primary font-medium">
-                    브라우저 설정 확인 중...
-                  </p>
-                </div>
-              )}
 
               {/* 버튼 */}
               <button

--- a/app/(main)/settings/page.tsx
+++ b/app/(main)/settings/page.tsx
@@ -1,28 +1,135 @@
 "use client"
 
-import { ArrowLeftIcon, ArrowLeftStartOnRectangleIcon, TrashIcon, ArrowRightOnRectangleIcon } from "@heroicons/react/24/outline"
+import { ArrowLeftIcon, ArrowLeftStartOnRectangleIcon, TrashIcon, ArrowRightOnRectangleIcon, BellIcon, Cog6ToothIcon } from "@heroicons/react/24/outline"
 import { Switch } from "@/components/ui/switch"
 import { useState, useEffect } from "react"
 import { useAuthContext } from "@/contexts/auth-context"
 import { useRouter } from "next/navigation"
-import { updateDeviceNotificationSettings } from "@/lib/notification-api"
-import { getOrCreateDeviceId } from "@/src/lib/fcmTokenManager"
+import { getDeviceNotificationSettings, updateDeviceNotificationSettings } from "@/lib/notification-api"
+import { getOrCreateDeviceId, requestFCMToken, onForegroundMessage, setupTokenRefreshListener } from "@/src/lib/fcmTokenManager"
 import { toast } from "sonner"
 
 export default function SettingsPage() {
-  const { logout, deleteAccount, isAuthenticated, user } = useAuthContext()
+  const { logout, deleteAccount, isAuthenticated, user, accessToken } = useAuthContext()
   const router = useRouter()
   const [showDeleteModal, setShowDeleteModal] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
   const [notificationsEnabled, setNotificationsEnabled] = useState(false)
   const [isUpdating, setIsUpdating] = useState(false)
+  const [showPermissionModal, setShowPermissionModal] = useState(false)
+  const [isCheckingPermission, setIsCheckingPermission] = useState(false)
 
-  // 페이지 로드 시 브라우저 알림 권한 상태로 초기화
+  // 페이지 로드 시 서버에서 알림 설정 조회
   useEffect(() => {
-    if (typeof window !== "undefined" && "Notification" in window) {
-      setNotificationsEnabled(Notification.permission === "granted")
+    const loadNotificationSettings = async () => {
+      try {
+        const deviceId = getOrCreateDeviceId()
+        const settings = await getDeviceNotificationSettings(deviceId)
+
+        // 서버의 실제 설정값으로 초기화
+        setNotificationsEnabled(settings.notificationEnabled)
+        console.log("알림 설정 조회 성공:", settings.notificationEnabled)
+      } catch (error: any) {
+        const errorMessage = error?.message || "알림 설정 조회 실패"
+        console.error("알림 설정 조회 오류:", errorMessage, error)
+
+        // 실패 시 브라우저 권한 상태로 폴백
+        if (typeof window !== "undefined" && "Notification" in window) {
+          setNotificationsEnabled(Notification.permission === "granted")
+        }
+      }
     }
+
+    loadNotificationSettings()
   }, [])
+
+  // 페이지 포커스 시 브라우저 권한과 서버 상태 동기화
+  useEffect(() => {
+    let isSyncing = false
+
+    const syncBrowserPermission = async () => {
+      if (!('Notification' in window) || isSyncing) return
+
+      isSyncing = true
+      try {
+        const deviceId = getOrCreateDeviceId()
+        const browserGranted = Notification.permission === 'granted'
+        const serverSettings = await getDeviceNotificationSettings(deviceId)
+
+        // 브라우저 권한과 서버 상태가 불일치하면 동기화
+        if (browserGranted !== serverSettings.notificationEnabled) {
+          console.log('[권한 동기화]', browserGranted ? '허용됨' : '차단됨')
+
+          // 권한 허용 시 FCM 토큰 재발급
+          if (browserGranted) {
+            const token = await requestFCMToken(accessToken)
+            if (token) {
+              await onForegroundMessage()
+              await setupTokenRefreshListener(accessToken)
+            }
+          }
+
+          await updateDeviceNotificationSettings(deviceId, browserGranted)
+          setNotificationsEnabled(browserGranted)
+
+          // 모달 자동 닫기
+          if (browserGranted && showPermissionModal) {
+            setShowPermissionModal(false)
+            setIsCheckingPermission(false)
+            toast.success('알림이 활성화되었습니다')
+          }
+        }
+      } catch (error: any) {
+        console.error('[권한 동기화 실패]', error?.message || error)
+      } finally {
+        isSyncing = false
+      }
+    }
+
+    // 초기 동기화
+    syncBrowserPermission()
+
+    // 페이지 포커스 시 동기화 (visibilitychange로 충분)
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        syncBrowserPermission()
+      }
+    }
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+
+    // Permissions API로 즉각 감지 (지원 브라우저)
+    if ('permissions' in navigator && 'query' in navigator.permissions) {
+      navigator.permissions.query({ name: 'notifications' as PermissionName })
+        .then((status) => {
+          status.addEventListener('change', () => {
+            console.log('[Permissions API] 권한 변경:', status.state)
+            syncBrowserPermission()
+          })
+        })
+        .catch(() => {})
+    }
+
+    // 모달 열려있을 때만 폴링 (폴백)
+    let pollInterval: NodeJS.Timeout | null = null
+    if (showPermissionModal) {
+      setIsCheckingPermission(true)
+
+      pollInterval = setInterval(() => {
+        if (Notification.permission === 'granted' && !isSyncing) {
+          clearInterval(pollInterval!)
+          setIsCheckingPermission(false)
+          syncBrowserPermission()
+        }
+      }, 200)
+    } else {
+      setIsCheckingPermission(false)
+    }
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+      if (pollInterval) clearInterval(pollInterval)
+    }
+  }, [showPermissionModal, accessToken])
 
   // 알림 설정 토글 변경 핸들러
   const handleNotificationToggle = async (enabled: boolean) => {
@@ -42,10 +149,10 @@ export default function SettingsPage() {
           await updateDeviceNotificationSettings(deviceId, true)
           console.log("알림 설정 업데이트 성공: true (기존 권한 사용)")
         } else if (currentPermission === "denied") {
-          // 권한이 차단된 경우 - 브라우저 설정에서 변경하도록 안내
+          // 권한이 차단된 경우 - 안내 모달 표시
           setNotificationsEnabled(false)
-          alert("브라우저 알림이 차단되어 있습니다.\n\n브라우저 주소창 왼쪽의 자물쇠 아이콘을 클릭하여 알림 권한을 허용해주세요.")
-          console.log("알림 권한이 차단되어 있음 (denied)")
+          setShowPermissionModal(true)
+          console.log("알림 권한이 차단되어 있음 (denied) - 모달 표시")
         } else {
           // 권한이 아직 결정되지 않은 경우 (default) - 권한 요청
           const permission = await Notification.requestPermission()
@@ -178,6 +285,86 @@ export default function SettingsPage() {
         )}
       </div>
 
+      {/* 알림 권한 안내 모달 */}
+      {showPermissionModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
+          {/* 배경 오버레이 */}
+          <div
+            className="absolute inset-0 bg-black/40"
+            onClick={() => setShowPermissionModal(false)}
+          />
+
+          {/* 모달 */}
+          <div className="relative bg-card rounded-2xl border border-border p-6 mx-5 max-w-sm w-full shadow-xl">
+            <div className="flex flex-col items-center text-center">
+              {/* 아이콘 */}
+              <div className="w-16 h-16 bg-primary/10 rounded-full flex items-center justify-center mb-4">
+                <BellIcon className="w-8 h-8 text-primary" />
+              </div>
+
+              {/* 제목 */}
+              <h3 className="text-lg font-semibold text-foreground mb-6">
+                알림 권한이 차단되어 있어요
+              </h3>
+
+              {/* 안내 단계 */}
+              <div className="w-full bg-muted/30 rounded-xl p-4 mb-4 text-left space-y-3">
+                <div className="flex items-start gap-3">
+                  <div className="w-6 h-6 rounded-full bg-primary/20 flex items-center justify-center flex-shrink-0 mt-0.5">
+                    <span className="text-xs font-semibold text-primary">1</span>
+                  </div>
+                  <div className="flex-1">
+                    <p className="text-sm text-foreground">
+                      주소창 왼쪽의 <strong className="text-primary">자물쇠 아이콘</strong>을 클릭하세요
+                    </p>
+                  </div>
+                </div>
+
+                <div className="flex items-start gap-3">
+                  <div className="w-6 h-6 rounded-full bg-primary/20 flex items-center justify-center flex-shrink-0 mt-0.5">
+                    <span className="text-xs font-semibold text-primary">2</span>
+                  </div>
+                  <div className="flex-1">
+                    <p className="text-sm text-foreground">
+                      <strong className="text-primary">알림</strong> 항목을 찾아 <strong className="text-primary">허용</strong>으로 변경하세요
+                    </p>
+                  </div>
+                </div>
+
+                <div className="flex items-start gap-3">
+                  <div className="w-6 h-6 rounded-full bg-primary/20 flex items-center justify-center flex-shrink-0 mt-0.5">
+                    <span className="text-xs font-semibold text-primary">3</span>
+                  </div>
+                  <div className="flex-1">
+                    <p className="text-sm text-foreground">
+                      이 페이지로 돌아오면 자동으로 적용됩니다
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              {/* 권한 확인 중 표시 */}
+              {isCheckingPermission && (
+                <div className="w-full bg-primary/10 rounded-xl p-3 mb-4 flex items-center gap-3">
+                  <div className="w-5 h-5 border-2 border-primary border-t-transparent rounded-full animate-spin" />
+                  <p className="text-sm text-primary font-medium">
+                    브라우저 설정 확인 중...
+                  </p>
+                </div>
+              )}
+
+              {/* 버튼 */}
+              <button
+                onClick={() => setShowPermissionModal(false)}
+                className="w-full py-3 px-4 bg-primary/60 text-white rounded-xl font-medium text-[15px] active:opacity-70 transition-opacity"
+              >
+                확인
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* 회원탈퇴 확인 모달 */}
       {showDeleteModal && (
         <div className="fixed inset-0 z-50 flex items-center justify-center">
@@ -205,14 +392,14 @@ export default function SettingsPage() {
                 <button
                   onClick={() => setShowDeleteModal(false)}
                   disabled={isDeleting}
-                  className="w-full py-3 px-4 bg-primary/60 text-white rounded-xl font-medium text-[15px] active:scale-95 transition-transform disabled:opacity-50"
+                  className="w-full py-3 px-4 bg-primary/60 text-white rounded-xl font-medium text-[15px] active:opacity-70 transition-opacity disabled:opacity-50"
                 >
                   계속 함께하기
                 </button>
                 <button
                   onClick={handleDeleteAccount}
                   disabled={isDeleting}
-                  className="w-full py-3 px-4 bg-muted text-muted-foreground rounded-xl font-medium text-[15px] active:scale-95 transition-transform disabled:opacity-50"
+                  className="w-full py-3 px-4 bg-muted text-muted-foreground rounded-xl font-medium text-[15px] active:opacity-70 transition-opacity disabled:opacity-50"
                 >
                   {isDeleting ? "탈퇴 중..." : "그래도 탈퇴할게요"}
                 </button>

--- a/lib/notification-api.ts
+++ b/lib/notification-api.ts
@@ -1,6 +1,35 @@
 // 알림 설정 관련 API
 
-import { apiPatch } from "./api-client"
+import { apiGet, apiPatch } from "./api-client"
+
+/**
+ * 디바이스 알림 설정 조회 응답
+ */
+export interface NotificationSettings {
+  notificationEnabled: boolean
+}
+
+/**
+ * 디바이스 알림 설정 조회
+ * GET /api/v1/notifications/devices/{deviceId}/notification-settings
+ */
+export async function getDeviceNotificationSettings(
+  deviceId: string
+): Promise<NotificationSettings> {
+  try {
+    const response = await apiGet<NotificationSettings>(
+      `/api/v1/notifications/devices/${deviceId}/notification-settings`
+    )
+    return response.data
+  } catch (error: any) {
+    // 404 에러는 디바이스 미등록 상태 (정상 케이스)
+    if (error?.status === 404) {
+      console.log('디바이스 미등록 - 기본값 사용')
+      return { notificationEnabled: false }
+    }
+    throw error
+  }
+}
 
 /**
  * 디바이스별 알림 수신 여부 변경

--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -1,6 +1,12 @@
 importScripts('https://www.gstatic.com/firebasejs/12.5.0/firebase-app-compat.js');
 importScripts('https://www.gstatic.com/firebasejs/12.5.0/firebase-messaging-compat.js');
 
+// FCM 상수 정의
+const FCM_MESSAGE_TYPES = {
+  TOKEN_REFRESHED: 'FCM_TOKEN_REFRESHED',
+  NAVIGATE: 'FCM_NAVIGATE',
+};
+
 // PWA 캐시 이름
 const CACHE_NAME = 'if-u-v1';
 const STATIC_ASSETS = [
@@ -93,7 +99,7 @@ messaging.onTokenRefresh(async () => {
       const clients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
       clients.forEach(client => {
         client.postMessage({
-          type: 'FCM_TOKEN_REFRESHED',
+          type: FCM_MESSAGE_TYPES.TOKEN_REFRESHED,
           token: newToken
         });
       });
@@ -143,7 +149,7 @@ self.addEventListener('notificationclick', (event) => {
         const client = clientList[0];
         client.focus();
         client.postMessage({
-          type: 'FCM_NAVIGATE',
+          type: FCM_MESSAGE_TYPES.NAVIGATE,
           redirectPath: redirectPath
         });
         return Promise.resolve();

--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -50,6 +50,11 @@ self.addEventListener('activate', (event) => {
 
 // 네트워크 요청 가로채기 (캐시 우선 전략)
 self.addEventListener('fetch', (event) => {
+  // GET 요청만 캐싱 처리 (POST, DELETE 등은 제외)
+  if (event.request.method !== 'GET') {
+    return;
+  }
+
   event.respondWith(
     caches.match(event.request).then((response) => {
       // 캐시에 있으면 캐시 반환, 없으면 네트워크 요청
@@ -85,29 +90,6 @@ firebase.initializeApp({
 });
 
 const messaging = firebase.messaging();
-
-// FCM 토큰 갱신 감지 (Service Worker)
-messaging.onTokenRefresh(async () => {
-  try {
-    console.log('FCM 토큰 갱신 이벤트 발생');
-    const newToken = await messaging.getToken();
-
-    if (newToken) {
-      console.log('새로운 FCM 토큰:', newToken);
-
-      // 클라이언트에 토큰 갱신 알림
-      const clients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
-      clients.forEach(client => {
-        client.postMessage({
-          type: FCM_MESSAGE_TYPES.TOKEN_REFRESHED,
-          token: newToken
-        });
-      });
-    }
-  } catch (error) {
-    console.error('토큰 갱신 중 오류:', error);
-  }
-});
 
 // 백그라운드 푸시 알림 수신
 messaging.onBackgroundMessage((payload) => {

--- a/src/components/FCMInitializer.tsx
+++ b/src/components/FCMInitializer.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { requestFCMToken, onForegroundMessage, setupTokenRefreshListener } from '@/src/lib/fcmTokenManager';
+import { FCM_CUSTOM_EVENTS, FCM_MESSAGE_TYPES } from '@/src/lib/fcmConstants';
 import { useAuthContext } from '@/contexts/auth-context';
 
 export default function FCMInitializer() {
@@ -18,17 +19,17 @@ export default function FCMInitializer() {
       router.push(redirectPath);
     };
 
-    window.addEventListener('fcm-navigate', handleFCMNavigate);
+    window.addEventListener(FCM_CUSTOM_EVENTS.NAVIGATE, handleFCMNavigate);
 
     return () => {
-      window.removeEventListener('fcm-navigate', handleFCMNavigate);
+      window.removeEventListener(FCM_CUSTOM_EVENTS.NAVIGATE, handleFCMNavigate);
     };
   }, [router]);
 
   // 백그라운드 알림 클릭 시 라우팅 처리 (Service Worker postMessage)
   useEffect(() => {
     const handleServiceWorkerMessage = (event: MessageEvent) => {
-      if (event.data?.type === 'FCM_NAVIGATE') {
+      if (event.data?.type === FCM_MESSAGE_TYPES.NAVIGATE) {
         const redirectPath = event.data.redirectPath;
         console.log('Service Worker 알림 클릭 - 페이지 이동:', redirectPath);
         router.push(redirectPath);

--- a/src/components/FCMInitializer.tsx
+++ b/src/components/FCMInitializer.tsx
@@ -62,20 +62,40 @@ export default function FCMInitializer() {
       try {
         console.log('FCM 초기화 시작');
 
-        // 1. Service Worker 먼저 등록하고 완료 대기
+        // 1. Service Worker 먼저 등록하고 활성화 대기
         if ('serviceWorker' in navigator) {
           console.log('Service Worker 등록 시도');
           const registration = await navigator.serviceWorker.register('/firebase-messaging-sw.js');
           console.log('Service Worker 등록 성공:', registration);
 
-          // Service Worker가 활성화될 때까지 대기
+          // Service Worker가 활성화될 때까지 명시적으로 대기
           if (registration.installing) {
             console.log('Service Worker 설치 중...');
+            await new Promise<void>((resolve) => {
+              registration.installing!.addEventListener('statechange', (e) => {
+                if ((e.target as ServiceWorker).state === 'activated') {
+                  console.log('Service Worker 활성화 완료');
+                  resolve();
+                }
+              });
+            });
           } else if (registration.waiting) {
             console.log('Service Worker 대기 중...');
+            await new Promise<void>((resolve) => {
+              registration.waiting!.addEventListener('statechange', (e) => {
+                if ((e.target as ServiceWorker).state === 'activated') {
+                  console.log('Service Worker 활성화 완료');
+                  resolve();
+                }
+              });
+            });
           } else if (registration.active) {
-            console.log('Service Worker 활성화됨');
+            console.log('Service Worker 이미 활성화됨');
           }
+
+          // Service Worker가 완전히 준비될 때까지 추가 대기
+          await navigator.serviceWorker.ready;
+          console.log('Service Worker 준비 완료');
         }
 
         // 2. Service Worker 준비 완료 후 FCM 토큰 요청

--- a/src/components/FCMInitializer.tsx
+++ b/src/components/FCMInitializer.tsx
@@ -69,28 +69,19 @@ export default function FCMInitializer() {
           console.log('Service Worker 등록 성공:', registration);
 
           // Service Worker가 활성화될 때까지 명시적으로 대기
-          if (registration.installing) {
-            console.log('Service Worker 설치 중...');
+          const workerToWatch = registration.installing || registration.waiting
+          if (workerToWatch) {
+            console.log(`Service Worker ${registration.installing ? '설치' : '대기'} 중...`)
             await new Promise<void>((resolve) => {
-              registration.installing!.addEventListener('statechange', (e) => {
+              workerToWatch.addEventListener('statechange', (e) => {
                 if ((e.target as ServiceWorker).state === 'activated') {
-                  console.log('Service Worker 활성화 완료');
-                  resolve();
+                  console.log('Service Worker 활성화 완료')
+                  resolve()
                 }
-              });
-            });
-          } else if (registration.waiting) {
-            console.log('Service Worker 대기 중...');
-            await new Promise<void>((resolve) => {
-              registration.waiting!.addEventListener('statechange', (e) => {
-                if ((e.target as ServiceWorker).state === 'activated') {
-                  console.log('Service Worker 활성화 완료');
-                  resolve();
-                }
-              });
-            });
+              })
+            })
           } else if (registration.active) {
-            console.log('Service Worker 이미 활성화됨');
+            console.log('Service Worker 이미 활성화됨')
           }
 
           // Service Worker가 완전히 준비될 때까지 추가 대기

--- a/src/lib/fcmConstants.ts
+++ b/src/lib/fcmConstants.ts
@@ -1,0 +1,20 @@
+/**
+ * FCM(Firebase Cloud Messaging) 관련 상수 정의
+ */
+
+// LocalStorage 키
+export const FCM_TOKEN_STORAGE_KEY = 'fcm_token';
+
+// Service Worker 메시지 타입
+export const FCM_MESSAGE_TYPES = {
+  TOKEN_REFRESHED: 'FCM_TOKEN_REFRESHED',
+  NAVIGATE: 'FCM_NAVIGATE',
+} as const;
+
+// CustomEvent 타입
+export const FCM_CUSTOM_EVENTS = {
+  NAVIGATE: 'fcm-navigate',
+} as const;
+
+// 토큰 갱신 주기 (밀리초)
+export const FCM_TOKEN_REFRESH_INTERVAL = 10 * 60 * 1000; // 10분

--- a/src/lib/fcmTokenManager.ts
+++ b/src/lib/fcmTokenManager.ts
@@ -2,7 +2,6 @@ import { messaging } from "./settingFCM";
 import { getToken, onMessage } from "firebase/messaging";
 import {
   FCM_TOKEN_STORAGE_KEY,
-  FCM_MESSAGE_TYPES,
   FCM_CUSTOM_EVENTS,
   FCM_TOKEN_REFRESH_INTERVAL
 } from "./fcmConstants";
@@ -80,6 +79,18 @@ export const requestFCMToken = async (accessToken?: string | null) => {
 
     if (permission === "granted") {
       console.log("알림 권한 허용됨 - FCM 토큰 발급 시작");
+
+      // Service Worker가 완전히 활성화될 때까지 대기
+      if ('serviceWorker' in navigator) {
+        try {
+          console.log("Service Worker 활성화 대기 중...");
+          await navigator.serviceWorker.ready;
+          console.log("Service Worker 활성화 완료");
+        } catch (error) {
+          console.error("Service Worker 대기 중 오류:", error);
+          return null;
+        }
+      }
 
       // messaging 함수 실행해서 객체 가져오기
       const messagingInstance = await messaging();
@@ -194,11 +205,6 @@ export const onForegroundMessage = async () => {
 
 /**
  * FCM 토큰 갱신 리스너 등록
- * 토큰이 자동으로 갱신되는 경우:
- * 1. 앱이 백업에서 복원된 경우
- * 2. 사용자가 앱 데이터를 삭제한 경우
- * 3. 사용자가 앱을 재설치한 경우
- * 4. Firebase에서 보안상의 이유로 토큰을 갱신한 경우
  */
 export const setupTokenRefreshListener = async (accessToken?: string | null) => {
   try {
@@ -208,24 +214,9 @@ export const setupTokenRefreshListener = async (accessToken?: string | null) => 
       return null;
     }
 
-    const handleServiceWorkerMessage = async (event: MessageEvent) => {
-      if (event.data?.type === FCM_MESSAGE_TYPES.TOKEN_REFRESHED) {
-        const newToken = event.data.token;
-        console.log("FCM 토큰 갱신 감지:", newToken);
-
-        // 서버에 새 토큰 업데이트
-        await saveTokenToServer(newToken, accessToken);
-      }
-    };
-
-    // Service Worker 메시지 리스너 등록 (토큰 갱신 감지)
-    if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.addEventListener('message', handleServiceWorkerMessage);
-      console.log("FCM 토큰 갱신 리스너 등록 완료");
-    }
+    console.log("FCM 토큰 주기적 검증 시작 (10분 간격)");
 
     // 주기적으로 토큰 검증 및 갱신 (10분마다)
-    // Firebase onTokenRefresh가 놓칠 수 있는 edge case 대비
     const tokenRefreshInterval = setInterval(async () => {
       try {
         const currentToken = await getToken(messagingInstance, {
@@ -250,9 +241,7 @@ export const setupTokenRefreshListener = async (accessToken?: string | null) => 
     // Cleanup 함수 반환
     return () => {
       clearInterval(tokenRefreshInterval);
-      if ('serviceWorker' in navigator) {
-        navigator.serviceWorker.removeEventListener('message', handleServiceWorkerMessage);
-      }
+      console.log("FCM 토큰 주기적 검증 중단");
     };
   } catch (error: any) {
     console.error("토큰 갱신 리스너 등록 실패:", error?.message || error);

--- a/src/lib/fcmTokenManager.ts
+++ b/src/lib/fcmTokenManager.ts
@@ -1,5 +1,11 @@
 import { messaging } from "./settingFCM";
 import { getToken, onMessage } from "firebase/messaging";
+import {
+  FCM_TOKEN_STORAGE_KEY,
+  FCM_MESSAGE_TYPES,
+  FCM_CUSTOM_EVENTS,
+  FCM_TOKEN_REFRESH_INTERVAL
+} from "./fcmConstants";
 
 const VAPID_KEY = process.env.NEXT_PUBLIC_FIREBASE_VAPID_KEY;
 
@@ -89,7 +95,7 @@ export const requestFCMToken = async (accessToken?: string | null) => {
       if (token) {
         console.log("FCM 토큰 발급 성공:", token);
         // localStorage에 토큰 저장 (갱신 감지용)
-        localStorage.setItem("fcm_token", token);
+        localStorage.setItem(FCM_TOKEN_STORAGE_KEY, token);
         await saveTokenToServer(token, accessToken);
         return token;
       } else {
@@ -178,7 +184,7 @@ export const onForegroundMessage = async () => {
       // 알림 클릭 시 페이지 이동 (CustomEvent로 React Router에 위임)
       notification.onclick = () => {
         window.focus();
-        window.dispatchEvent(new CustomEvent('fcm-navigate', { detail: redirectPath }));
+        window.dispatchEvent(new CustomEvent(FCM_CUSTOM_EVENTS.NAVIGATE, { detail: redirectPath }));
       };
     }
   });
@@ -202,18 +208,19 @@ export const setupTokenRefreshListener = async (accessToken?: string | null) => 
       return null;
     }
 
+    const handleServiceWorkerMessage = async (event: MessageEvent) => {
+      if (event.data?.type === FCM_MESSAGE_TYPES.TOKEN_REFRESHED) {
+        const newToken = event.data.token;
+        console.log("FCM 토큰 갱신 감지:", newToken);
+
+        // 서버에 새 토큰 업데이트
+        await saveTokenToServer(newToken, accessToken);
+      }
+    };
+
     // Service Worker 메시지 리스너 등록 (토큰 갱신 감지)
     if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.addEventListener('message', async (event) => {
-        if (event.data?.type === 'FCM_TOKEN_REFRESHED') {
-          const newToken = event.data.token;
-          console.log("FCM 토큰 갱신 감지:", newToken);
-
-          // 서버에 새 토큰 업데이트
-          await saveTokenToServer(newToken, accessToken);
-        }
-      });
-
+      navigator.serviceWorker.addEventListener('message', handleServiceWorkerMessage);
       console.log("FCM 토큰 갱신 리스너 등록 완료");
     }
 
@@ -227,22 +234,25 @@ export const setupTokenRefreshListener = async (accessToken?: string | null) => 
 
         if (currentToken) {
           // localStorage에 저장된 마지막 토큰과 비교
-          const lastToken = localStorage.getItem("fcm_token");
+          const lastToken = localStorage.getItem(FCM_TOKEN_STORAGE_KEY);
 
           if (lastToken !== currentToken) {
             console.log("FCM 토큰 변경 감지 (주기적 검증) - 서버 업데이트");
-            localStorage.setItem("fcm_token", currentToken);
+            localStorage.setItem(FCM_TOKEN_STORAGE_KEY, currentToken);
             await saveTokenToServer(currentToken, accessToken);
           }
         }
       } catch (error: any) {
         console.error("토큰 갱신 검증 실패:", error?.message || error);
       }
-    }, 10 * 60 * 1000); // 10분 (600초)
+    }, FCM_TOKEN_REFRESH_INTERVAL);
 
     // Cleanup 함수 반환
     return () => {
       clearInterval(tokenRefreshInterval);
+      if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.removeEventListener('message', handleServiceWorkerMessage);
+      }
     };
   } catch (error: any) {
     console.error("토큰 갱신 리스너 등록 실패:", error?.message || error);


### PR DESCRIPTION
## 🔗 Issue Link
<!-- 관련 이슈 번호를 적어주세요. 해당 PR merge와 함께 이슈를 닫으려면 `close #이슈번호`를 적어주세요. -->
#31 

## 🎯 What I Did
<!-- 이번 PR에서 구현하거나 수정한 주요 내용을 간결히 기술하세요. -->
- 브라우저 알림 권한과 앱 내 알림 설정을 독립적으로 관리하도록 개선
- 브라우저 설정에서 알림 권한 변경 시 앱 내 토글이 자동으로 동기화되도록 구현
- 사용자가 의도적으로 끈 알림 설정이 브라우저 권한과 무관하게 유지되도록 수정
- 페이지 포커스/탭 전환 시 DB 값 기반으로 토글 상태를 실시간 동기화

## ✅ Testing Checklist
- [x] 브라우저 설정에서 알림 허용 → 토글 자동 ON 확인
- [x] 브라우저 설정에서 알림 차단 → 토글 자동 OFF 확인
- [x] 토글 OFF 후 재진입 시 OFF 상태 유지 확인
- [x] 모달 안내를 통한 권한 허용 플로우 정상 작동 확인
- [x] 탭 전환 시 토글 상태 동기화 확인

